### PR TITLE
Create decorators for Conduit-specific HTTP functionality

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -2,8 +2,6 @@
 namespace Phly\Conduit;
 
 use Exception;
-use Phly\Http\ResponseInterface as Response;
-use Psr\Http\Message\RequestInterface as Request;
 
 /**
  * Dispatch middleware
@@ -36,15 +34,15 @@ class Dispatch
      *
      * @param Route $route
      * @param mixed $err
-     * @param Request $request
-     * @param Response $response
+     * @param Http\Request $request
+     * @param Http\Response $response
      * @param callable $next
      */
     public function __invoke(
         Route $route,
         $err,
-        Request $request,
-        Response $response,
+        Http\Request $request,
+        Http\Response $response,
         callable $next
     ) {
         $arity    = Utils::getArity($route->handler);

--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -2,9 +2,6 @@
 namespace Phly\Conduit;
 
 use Exception;
-use Phly\Http\Request as PhlyRequest;
-use Phly\Http\ResponseInterface as Response;
-use Psr\Http\Message\RequestInterface as Request;
 use Zend\Escaper\Escaper;
 
 /**
@@ -18,20 +15,20 @@ class FinalHandler
     private $options;
 
     /**
-     * @var Request
+     * @var Http\Request
      */
     private $request;
 
     /**
-     * @var Response
+     * @var Http\Response
      */
     private $response;
 
     /**
-     * @param Request $request
-     * @param Response $response
+     * @param Http\Request $request
+     * @param Http\Response $response
      */
-    public function __construct(Request $request, Response $response, array $options = [])
+    public function __construct(Http\Request $request, Http\Response $response, array $options = [])
     {
         $this->request  = $request;
         $this->response = $response;
@@ -91,12 +88,7 @@ class FinalHandler
     {
         $this->response->setStatusCode(404);
 
-        if ($this->request instanceof PhlyRequest && $this->request->originalUrl) {
-            $url = $this->request->originalUrl;
-        } else {
-            $url = $this->request->getUrl();
-        }
-
+        $url     = $this->request->originalUrl ?: $this->request->getUrl();
         $escaper = new Escaper();
         $message = sprintf(
             "Cannot %s %s\n",
@@ -116,10 +108,10 @@ class FinalHandler
      * less than 400 or greater than 599, returns 500; otherwise, returns it.
      *
      * @param mixed $error
-     * @param Response $response
+     * @param Http\Response $response
      * @return int
      */
-    private function getStatusCode($error, Response $response)
+    private function getStatusCode($error, Http\Response $response)
     {
         if ($error instanceof Exception
             && ($error->getCode() >= 400 && $error->getCode() < 600)
@@ -152,10 +144,10 @@ class FinalHandler
      * Trigger the error listener, if present
      *
      * @param mixed $error
-     * @param Request $request
-     * @param Response $response
+     * @param Http\Request $request
+     * @param Http\Response $response
      */
-    private function triggerError($error, Request $request, Response $response)
+    private function triggerError($error, Http\Request $request, Http\Response $response)
     {
         if (! isset($this->options['onerror'])
             || ! is_callable($this->options['onerror'])

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,0 +1,268 @@
+<?php
+namespace Phly\Conduit\Http;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Decorator for PSR RequestInterface
+ *
+ * Decorates the PSR request interface to add the ability to manipulate
+ * arbitrary instance members.
+ */
+class Request implements RequestInterface
+{
+    /**
+     * User request parameters
+     *
+     * @var array
+     */
+    private $params = array();
+
+    /**
+     * @var RequestInterface
+     */
+    private $psrRequest;
+
+    /**
+     * @param RequestInterface $request
+     */
+    public function __construct(RequestInterface $request)
+    {
+        $this->psrRequest = $request;
+    }
+
+    /**
+     * Return the original PSR request object
+     *
+     * @return RequestInterface
+     */
+    public function getOriginalRequest()
+    {
+        return $this->psrRequest;
+    }
+
+    /**
+     * Property overloading: get property value
+     *
+     * Returns null if property is not set.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if (! array_key_exists($name, $this->params)) {
+            return null;
+        }
+        return $this->params[$name];
+    }
+
+    /**
+     * Property overloading: set property
+     *
+     * @param string $name
+     * @param mixed $value
+     */
+    public function __set($name, $value)
+    {
+        $this->params[$name] = $value;
+    }
+
+    /**
+     * Property overloading: is property set?
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return array_key_exists($name, $this->params);
+    }
+
+    /**
+     * Property overloading: unset property
+     *
+     * @param string $name
+     */
+    public function __unset($name)
+    {
+        if (! array_key_exists($name, $this->params)) {
+            return;
+        }
+        unset($this->params[$name]);
+    }
+
+    /**
+     * Proxy to RequestInterface::getProtocolVersion()
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion()
+    {
+        return $this->psrRequest->getProtocolVersion();
+    }
+
+    /**
+     * Proxy to RequestInterface::getBody()
+     *
+     * @return StreamInterface|null Returns the body, or null if not set.
+     */
+    public function getBody()
+    {
+        return $this->psrRequest->getProtocolVersion();
+    }
+
+    /**
+     * Proxy to RequestInterface::setBody()
+     *
+     * @param StreamInterface|null $body Body.
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function setBody(StreamInterface $body = null)
+    {
+        return $this->psrRequest->setBody($body);
+    }
+
+    /**
+     * Proxy to RequestInterface::getHeaders()
+     *
+     * @return array Returns an associative array of the message's headers.
+     */
+    public function getHeaders()
+    {
+        return $this->psrRequest->getHeaders();
+    }
+
+    /**
+     * Proxy to RequestInterface::hasHeader()
+     *
+     * @param string $header Case-insensitive header name.
+     * @return bool Returns true if any header names match the given header
+     *     name using a case-insensitive string comparison. Returns false if
+     *     no matching header name is found in the message.
+     */
+    public function hasHeader($header)
+    {
+        return $this->psrRequest->hasHeader($header);
+    }
+
+    /**
+     * Proxy to RequestInterface::getHeader()
+     *
+     * @param string $header Case-insensitive header name.
+     * @return string
+     */
+    public function getHeader($header)
+    {
+        return $this->psrRequest->getHeader($header);
+    }
+
+    /**
+     * Proxy to RequestInterface::getHeaderAsArray()
+     *
+     * @param string $header Case-insensitive header name.
+     * @return string[]
+     */
+    public function getHeaderAsArray($header)
+    {
+        return $this->psrRequest->getHeaderAsArray($header);
+    }
+
+    /**
+     * Proxy to RequestInterface::setHeader()
+     *
+     * @param string $header Header name
+     * @param string|string[] $value  Header value(s)
+     */
+    public function setHeader($header, $value)
+    {
+        return $this->psrRequest->setHeader($header, $value);
+    }
+
+    /**
+     * Proxy to RequestInterface::setHeaders()
+     *
+     * @param array $headers Headers to set.
+     */
+    public function setHeaders(array $headers)
+    {
+        return $this->psrRequest->setHeaders($headers);
+    }
+
+    /**
+     * Proxy to RequestInterface::addHeader()
+     *
+     * @param string $header Header name to add
+     * @param string $value  Value of the header
+     */
+    public function addHeader($header, $value)
+    {
+        return $this->psrRequest->addHeader($header, $value);
+    }
+
+    /**
+     * Proxy to RequestInterface::addHeaders()
+     *
+     * @param array $headers Associative array of headers to add to the message
+     */
+    public function addHeaders(array $headers)
+    {
+        return $this->psrRequest->addHeaders($headers);
+    }
+
+    /**
+     * Proxy to RequestInterface::removeHeader()
+     *
+     * @param string $header HTTP header to remove
+     */
+    public function removeHeader($header)
+    {
+        return $this->psrRequest->removeHeader($header);
+    }
+
+    /**
+     * Proxy to RequestInterface::getMethod()
+     *
+     * @return string Returns the request method.
+     */
+    public function getMethod()
+    {
+        return $this->psrRequest->getMethod();
+    }
+
+    /**
+     * Proxy to RequestInterface::setMethod()
+     *
+     * @param string $method Case-insensitive method.
+     */
+    public function setMethod($method)
+    {
+        return $this->psrRequest->setMethod($method);
+    }
+
+    /**
+     * Proxy to RequestInterface::getUrl()
+     *
+     * @return string|object Returns the URL as a string, or an object that
+     *    implements the `__toString()` method. The URL must be an absolute URI
+     *    as specified in RFC 3986.
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     */
+    public function getUrl()
+    {
+        return $this->psrRequest->getUrl();
+    }
+
+    /**
+     * Proxy to RequestInterface::setUrl()
+     *
+     * @param string|object $url Request URL.
+     * @throws \InvalidArgumentException If the URL is invalid.
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     */
+    public function setUrl($url)
+    {
+        return $this->psrRequest->setUrl($url);
+    }
+}

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,0 +1,296 @@
+<?php
+namespace Phly\Conduit\Http;
+
+use Psr\Http\Message\ResponseInterface as BaseResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Response decorator
+ *
+ * Adds in write, end, and isComplete from RequestInterface in order
+ * to provide a common interface for all PSR HTTP implementations.
+ */
+class Response implements
+    BaseResponseInterface,
+    ResponseInterface
+{
+    /**
+     * @var bool
+     */
+    private $complete = false;
+
+    /**
+     * @var BaseResponseInterface
+     */
+    private $psrResponse;
+
+    /**
+     * @param BaseResponseInterface $response
+     */
+    public function __construct(BaseResponseInterface $response)
+    {
+        $this->psrResponse = $response;
+    }
+
+    /**
+     * Return the original PSR response object
+     *
+     * @return BaseResponseInterface
+     */
+    public function getOriginalResponse()
+    {
+        return $this->psrResponse;
+    }
+
+    /**
+     * Write data to the response body
+     *
+     * Proxies to the underlying stream and writes the provided data to it.
+     *
+     * @param string $data
+     */
+    public function write($data)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        $this->getBody()->write($data);
+    }
+
+    /**
+     * Mark the response as complete
+     *
+     * A completed response should no longer allow manipulation of either
+     * headers or the content body.
+     *
+     * If $data is passed, that data should be written to the response body
+     * prior to marking the response as complete.
+     *
+     * @param string $data
+     */
+    public function end($data = null)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        if ($data) {
+            $this->write($data);
+        }
+
+        $this->complete = true;
+    }
+
+    /**
+     * Indicate whether or not the response is complete.
+     *
+     * I.e., if end() has previously been called.
+     *
+     * @return bool
+     */
+    public function isComplete()
+    {
+        return $this->complete;
+    }
+
+    /**
+     * Proxy to ResponseInterface::
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion()
+    {
+        return $this->psrResponse->getProtocolVersion();
+    }
+
+    /**
+     * Proxy to ResponseInterface::getBody()
+     *
+     * @return StreamInterface|null Returns the body, or null if not set.
+     */
+    public function getBody()
+    {
+        return $this->psrResponse->getBody();
+    }
+
+    /**
+     * Proxy to ResponseInterface::setBody()
+     *
+     * @param StreamInterface|null $body Body.
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function setBody(StreamInterface $body = null)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->setBody($body);
+    }
+
+    /**
+     * Proxy to ResponseInterface::getHeaders()
+     *
+     * @return array Returns an associative array of the message's headers.
+     */
+    public function getHeaders()
+    {
+        return $this->psrResponse->getHeaders();
+    }
+
+    /**
+     * Proxy to ResponseInterface::hasHeader()
+     *
+     * @param string $header Case-insensitive header name.
+     * @return bool Returns true if any header names match the given header
+     *     name using a case-insensitive string comparison. Returns false if
+     *     no matching header name is found in the message.
+     */
+    public function hasHeader($header)
+    {
+        return $this->psrResponse->hasHeader($header);
+    }
+
+    /**
+     * Proxy to ResponseInterface::getHeader()
+     *
+     * @param string $header Case-insensitive header name.
+     * @return string
+     */
+    public function getHeader($header)
+    {
+        return $this->psrResponse->getHeader($header);
+    }
+
+    /**
+     * Proxy to ResponseInterface::getHeaderAsArray()
+     *
+     * @param string $header Case-insensitive header name.
+     * @return string[]
+     */
+    public function getHeaderAsArray($header)
+    {
+        return $this->psrResponse->getHeaderAsArray($header);
+    }
+
+    /**
+     * Proxy to ResponseInterface::setHeader()
+     *
+     * @param string $header Header name
+     * @param string|string[] $value  Header value(s)
+     */
+    public function setHeader($header, $value)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->setHeader($header, $value);
+    }
+
+    /**
+     * Proxy to ResponseInterface::setHeaders()
+     *
+     * @param array $headers Headers to set.
+     */
+    public function setHeaders(array $headers)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->setHeaders($headers);
+    }
+
+    /**
+     * Proxy to ResponseInterface::addHeader()
+     *
+     * @param string $header Header name to add
+     * @param string $value  Value of the header
+     */
+    public function addHeader($header, $value)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->addHeader($header, $value);
+    }
+
+    /**
+     * Proxy to ResponseInterface::addHeaders()
+     *
+     * @param array $headers Associative array of headers to add to the message
+     */
+    public function addHeaders(array $headers)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->addHeaders($headers);
+    }
+
+    /**
+     * Proxy to ResponseInterface::removeHeader()
+     *
+     * @param string $header HTTP header to remove
+     */
+    public function removeHeader($header)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->removeHeader($header);
+    }
+
+    /**
+     * Proxy to ResponseInterface::getStatusCode()
+     *
+     * @return integer Status code.
+     */
+    public function getStatusCode()
+    {
+        return $this->psrResponse->getStatusCode();
+    }
+
+    /**
+     * Proxy to ResponseInterface::setStatusCode()
+     *
+     * @param integer $code The 3-digit integer result code to set.
+     */
+    public function setStatusCode($code)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->setStatusCode($code);
+    }
+
+    /**
+     * Proxy to ResponseInterface::getReasonPhrase()
+     *
+     * @return string|null Reason phrase, or null if unknown.
+     */
+    public function getReasonPhrase()
+    {
+        return $this->psrResponse->getReasonPhrase();
+    }
+
+    /**
+     * Proxy to ResponseInterface::setReasonPhrase()
+     *
+     * @param string $phrase The Reason-Phrase to set.
+     */
+    public function setReasonPhrase($phrase)
+    {
+        if ($this->complete) {
+            return;
+        }
+
+        return $this->psrResponse->setReasonPhrase($phrase);
+    }
+}

--- a/src/Http/ResponseInterface.php
+++ b/src/Http/ResponseInterface.php
@@ -1,0 +1,45 @@
+<?php
+namespace Phly\Conduit\Http;
+
+/**
+ * Response convenience methods
+ *
+ * Defines the following respones capabilities:
+ *
+ * - Write to the content
+ * - End the response (mark it complete)
+ * - Determine if the response is complete
+ */
+interface ResponseInterface
+{
+    /**
+     * Write data to the response body
+     *
+     * Proxies to the underlying stream and writes the provided data to it.
+     *
+     * @param string $data
+     */
+    public function write($data);
+
+    /**
+     * Mark the response as complete
+     *
+     * A completed response should no longer allow manipulation of either
+     * headers or the content body.
+     *
+     * If $data is passed, that data should be written to the response body
+     * prior to marking the response as complete.
+     *
+     * @param string $data
+     */
+    public function end($data = null);
+
+    /**
+     * Indicate whether or not the response is complete.
+     *
+     * I.e., if end() has previously been called.
+     *
+     * @return bool
+     */
+    public function isComplete();
+}

--- a/src/Next.php
+++ b/src/Next.php
@@ -2,8 +2,6 @@
 namespace Phly\Conduit;
 
 use ArrayObject;
-use Phly\Http\ResponseInterface as Response;
-use Psr\Http\Message\RequestInterface as Request;
 
 /**
  * Iterate a stack of middlewares and execute them
@@ -31,12 +29,12 @@ class Next
     private $removed = '';
 
     /**
-     * @var Request
+     * @var Http\Request
      */
     private $request;
 
     /**
-     * @var Response
+     * @var Http\Response
      */
     private $response;
 
@@ -47,11 +45,11 @@ class Next
 
     /**
      * @param ArrayObject $stack
-     * @param Request $request
-     * @param Response $response
+     * @param Http\Request $request
+     * @param Http\Response $response
      * @param callable $done
      */
-    public function __construct(ArrayObject $stack, Request $request, Response $response, callable $done)
+    public function __construct(ArrayObject $stack, Http\Request $request, Http\Response $response, callable $done)
     {
         $this->dispatch = new Dispatch();
 
@@ -105,9 +103,9 @@ class Next
     /**
      * Reset the path, if a segment was previously stripped
      *
-     * @param Request $request
+     * @param Http\Request $request
      */
-    private function resetPath(Request $request)
+    private function resetPath(Http\Request $request)
     {
         if (! $this->removed) {
             return;

--- a/test/DispatchTest.php
+++ b/test/DispatchTest.php
@@ -10,8 +10,12 @@ class DispatchTest extends TestCase
 {
     public function setUp()
     {
-        $this->request  = $this->getMock('Psr\Http\Message\RequestInterface');
-        $this->response = $this->getMock('Phly\Http\ResponseInterface');
+        $this->request  = $this->getMockBuilder('Phly\Conduit\Http\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->response = $this->getMockBuilder('Phly\Conduit\Http\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     public function testHasErrorAndHandleArityIsFourTriggersHandler()

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -3,8 +3,10 @@ namespace PhlyTest\Conduit;
 
 use Exception;
 use Phly\Conduit\FinalHandler;
-use Phly\Http\Request;
-use Phly\Http\Response;
+use Phly\Conduit\Http\Request;
+use Phly\Conduit\Http\Response;
+use Phly\Http\Request as PsrRequest;
+use Phly\Http\Response as PsrResponse;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Escaper\Escaper;
 
@@ -13,8 +15,8 @@ class FinalHandlerTest extends TestCase
     public function setUp()
     {
         $this->escaper  = new Escaper();
-        $this->request  = new Request('1.1', 'php://memory');
-        $this->response = new Response();
+        $this->request  = new Request(new PsrRequest('1.1', 'php://memory'));
+        $this->response = new Response(new PsrResponse());
         $this->final    = new FinalHandler($this->request, $this->response);
     }
 

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace PhlyTest\Conduit\Http;
+
+use Phly\Conduit\Http\Request;
+use Phly\Http\Request as PsrRequest;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class RequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new Request(new PsrRequest());
+    }
+
+    public function testAllowsManipulatingArbitraryNonPrivateProperties()
+    {
+        $this->request->originalUrl = 'http://foo.example.com/foo';
+        $this->assertTrue(isset($this->request->originalUrl));
+        $this->assertEquals('http://foo.example.com/foo', $this->request->originalUrl);
+        unset($this->request->originalUrl);
+        $this->assertNull($this->request->originalUrl);
+    }
+
+    public function testFetchingUnknownPropertyYieldsNull()
+    {
+        $this->assertNull($this->request->somePropertyWeMadeUp);
+    }
+}

--- a/test/Http/ResponseTest.php
+++ b/test/Http/ResponseTest.php
@@ -1,0 +1,94 @@
+<?php
+namespace PhlyTest\Conduit\Http;
+
+use Phly\Conduit\Http\Response;
+use Phly\Http\Response as PsrResponse;
+use Phly\Http\Stream;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ResponseTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->response = new Response(new PsrResponse());
+    }
+
+    public function testIsNotCompleteByDefault()
+    {
+        $this->assertFalse($this->response->isComplete());
+    }
+
+    public function testCallingEndMarksAsComplete()
+    {
+        $this->response->end();
+        $this->assertTrue($this->response->isComplete());
+    }
+
+    public function testWriteAppendsBody()
+    {
+        $this->response->write("First\n");
+        $this->assertContains('First', (string) $this->response->getBody());
+        $this->response->write("Second\n");
+        $this->assertContains('First', (string) $this->response->getBody());
+        $this->assertContains('Second', (string) $this->response->getBody());
+    }
+
+    public function testCannotMutateResponseAfterCallingEnd()
+    {
+        $this->response->setStatusCode(201);
+        $this->response->write("First\n");
+        $this->response->end('DONE');
+
+        $this->response->setStatusCode(200);
+        $this->response->setHeader('X-Foo', 'Foo');
+        $this->response->write('MOAR!');
+
+        $this->assertEquals(201, $this->response->getStatusCode());
+        $this->assertFalse($this->response->hasHeader('X-Foo'));
+        $this->assertNotContains('MOAR!', (string) $this->response->getBody());
+        $this->assertContains('First', (string) $this->response->getBody());
+        $this->assertContains('DONE', (string) $this->response->getBody());
+    }
+
+    public function testSetBodyReturnsEarlyIfComplete()
+    {
+        $this->response->end('foo');
+
+        $body = new Stream('php://memory', 'r+');
+        $this->response->setBody($body);
+
+        $this->assertEquals('foo', (string) $this->response->getBody());
+    }
+
+    public function testSetHeadersDoesNothingIfComplete()
+    {
+        $this->response->end('foo');
+        $this->response->setHeaders([
+            'Content-Type' => 'application/json',
+        ]);
+        $this->assertFalse($this->response->hasHeader('Content-Type'));
+    }
+
+    public function testAddHeaderDoesNothingIfComplete()
+    {
+        $this->response->end('foo');
+        $this->response->addHeader('Content-Type', 'application/json');
+        $this->assertFalse($this->response->hasHeader('Content-Type'));
+    }
+
+    public function testAddHeadersDoesNothingIfComplete()
+    {
+        $this->response->end('foo');
+        $this->response->addHeaders([
+            'Content-Type' => 'application/json',
+        ]);
+        $this->assertFalse($this->response->hasHeader('Content-Type'));
+    }
+
+    public function testCallingEndMultipleTimesDoesNothingAfterFirstCall()
+    {
+        $this->response->end('foo');
+        $this->response->end('bar');
+        $this->assertEquals('foo', (string) $this->response->getBody());
+    }
+}

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -2,10 +2,12 @@
 namespace PhlyTest\Conduit;
 
 use ArrayObject;
-use Phly\Http\Request;
-use Phly\Http\Response;
+use Phly\Conduit\Http\Request;
+use Phly\Conduit\Http\Response;
 use Phly\Conduit\Next;
 use Phly\Conduit\Route;
+use Phly\Http\Request as PsrRequest;
+use Phly\Http\Response as PsrResponse;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class NextTest extends TestCase
@@ -13,8 +15,8 @@ class NextTest extends TestCase
     public function setUp()
     {
         $this->stack    = new ArrayObject();
-        $this->request  = new Request('1.1', 'php://memory');
-        $this->response = new Response();
+        $this->request  = new Request(new PsrRequest('1.1', 'php://memory'));
+        $this->response = new Response(new PsrResponse());
     }
 
     public function testDoneHandlerIsInvokedWhenStackIsExhausted()


### PR DESCRIPTION
This PR creates HTTP request and response decorators for functionality specific to Conduit. The functionality includes:
- Request objects should allow arbitrary property access.
- Response objects should implement `write()`, `end()`, and `isComplete()`.

Essentially, this allows using any arbitrary PSR HTTP implementation; `Middleware` then decorates those instances before doing its work, ensuring that its own functionality can be met (e.g., `originalUrl` in the request, `end()` in the response, etc.).
