### PR TITLE
Added $originalUrl to request implementation

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\StreamInterface;
  *
  * Decorates the PSR request interface to add the ability to manipulate
  * arbitrary instance members.
+ *
+ * @property \Phly\Http\Uri $originalUrl Original URL of this instance
  */
 class Request implements RequestInterface
 {
@@ -257,12 +259,18 @@ class Request implements RequestInterface
     /**
      * Proxy to RequestInterface::setUrl()
      *
+     * Also sets originalUrl property if not previously set.
+     *
      * @param string|object $url Request URL.
      * @throws \InvalidArgumentException If the URL is invalid.
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      */
     public function setUrl($url)
     {
-        return $this->psrRequest->setUrl($url);
+        $this->psrRequest->setUrl($url);
+
+        if (! $this->originalUrl) {
+            $this->originalUrl = $this->psrRequest->getUrl();
+        }
     }
 }

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -3,6 +3,7 @@ namespace PhlyTest\Conduit\Http;
 
 use Phly\Conduit\Http\Request;
 use Phly\Http\Request as PsrRequest;
+use Phly\Http\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestTest extends TestCase
@@ -24,5 +25,13 @@ class RequestTest extends TestCase
     public function testFetchingUnknownPropertyYieldsNull()
     {
         $this->assertNull($this->request->somePropertyWeMadeUp);
+    }
+
+    public function testCallingSetUrlSetsOriginalUrlProperty()
+    {
+        $url = 'http://example.com/foo';
+        $uri = new Uri($url);
+        $this->request->setUrl($uri);
+        $this->assertSame($uri, $this->request->originalUrl);
     }
 }


### PR DESCRIPTION
- setUrl() now sets $originalUrl if not previously present.
