### PR TITLE
Ensure originalUrl is present at construction

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -32,6 +32,7 @@ class Request implements RequestInterface
     public function __construct(RequestInterface $request)
     {
         $this->psrRequest = $request;
+        $this->originalUrl = $request->getUrl();
     }
 
     /**

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -34,4 +34,13 @@ class RequestTest extends TestCase
         $this->request->setUrl($uri);
         $this->assertSame($uri, $this->request->originalUrl);
     }
+
+    public function testConstructorSetsOriginalUrlIfDecoratedRequestHasUrl()
+    {
+        $url = 'http://example.com/foo';
+        $baseRequest = new PsrRequest();
+        $baseRequest->setUrl($url);
+        $request = new Request($baseRequest);
+        $this->assertSame($baseRequest->getUrl(), $request->originalUrl);
+    }
 }


### PR DESCRIPTION
- This fixes an issue whereby a PSR request is present at instantiation,
  and has the URI present, but setUrl() is never called on the
  decorator.
