### PR TITLE
Cast array properties to ArrayObject

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,6 +1,7 @@
 <?php
 namespace Phly\Conduit\Http;
 
+use ArrayObject;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -69,6 +70,9 @@ class Request implements RequestInterface
      */
     public function __set($name, $value)
     {
+        if (is_array($value)) {
+            $value = new ArrayObject($value, ArrayObject::ARRAY_AS_PROPS);
+        }
         $this->params[$name] = $value;
     }
 

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -28,6 +28,14 @@ class RequestTest extends TestCase
         $this->assertNull($this->request->somePropertyWeMadeUp);
     }
 
+    public function testArrayPropertyValueIsCastToArrayObject()
+    {
+        $original = ['test' => 'value'];
+        $this->request->anArray = $original;
+        $this->assertInstanceOf('ArrayObject', $this->request->anArray);
+        $this->assertEquals($original, $this->request->anArray->getArrayCopy());
+    }
+
     public function testCallingSetUrlSetsOriginalUrlProperty()
     {
         $url = 'http://example.com/foo';


### PR DESCRIPTION
Until late in PHP 5.4's lifecycle, dereferencing array property values can
lead to problems. As such, `__set()` now casts arrays to `ArrayObject` to
ensure that dereferencing works properly.
