### PR TITLE
Update to psr/http-message 0.3.0, phly/http 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.6.0 - TBD
+
+Updated to psr/http-message 0.3.0 and phly/http 0.5.0. The changes required to do so are not backwards incompatible. In particular, all typehints against `Psr\Http\Message\RequestInterface` have been changed to `Psr\Http\Message\IncomingRequestInterface`, as the middleware in Conduit is expected to be server-side, and accept incoming requests.
+
+### Added
+
+- `Phly\Conduit\Http\Request` now implements `Psr\Http\Message\IncomingRequestInterface`, and defines the following new methods:
+  - `getCookieParams()`
+  - `setCookieParams($cookies)`
+  - `getQueryParams()`
+  - `getFileParams()`
+  - `getBodyParams()`
+  - `setBodyParams($values)`
+  - `getPathParams()`
+  - `setPathParams(array $values)`
+- `Phly\Conduit\Http\Request` adds a `setProtocolVersion()` method, as it is now defined in `Psr\Http\Message\MessageInterface`.
+- `Phly\Conduit\Http\Response` adds a `setProtocolVersion()` method, as it is now defined in `Psr\Http\Message\MessageInterface`.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- `Phly\Http\Middleware::__invoke` now typehints the `$request` argument against `Psr\Http\Message\IncomingRequestInterface`.
+
 ## 0.5.1 - 2014-10-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation and Requirements
 Install this library using composer:
 
 ```console
-$ composer require "psr/http-message:~0.2.0@dev" "phly/http:~1.0-dev@dev" "phly/conduit:~1.0-dev@dev"
+$ composer require "psr/http-message:~0.3.0@dev" "phly/http:~1.0-dev@dev" "phly/conduit:~1.0-dev@dev"
 ```
 
 Conduit has the following dependencies (which are managed by Composer):
@@ -46,7 +46,13 @@ use Phly\Http\Server;
 require __DIR__ . '/../vendor/autoload.php';
 
 $app    = new Middleware();
-$server = Server::createServer($app, $_SERVER);
+$server = Server::createServer($app,
+  $_SERVER,
+  $_GET,
+  $_POST,
+  $_COOKIE,
+  $_FILES
+);
 $server->listen();
 ```
 
@@ -66,7 +72,7 @@ use Phly\Http\Server;
 require __DIR__ . '/../vendor/autoload.php';
 
 $app    = new Middleware();
-$server = Server::createServer($app, $_SERVER);
+$server = Server::createServer($app, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
 
 // Landing page
 $app->pipe('/', function ($req, $res, $next) {
@@ -163,7 +169,7 @@ In all cases, if you wish to implement typehinting, the signature is:
 
 ```php
 function (
-    Psr\Http\Message\RequestInterface $request,
+    Psr\Http\Message\IncomingRequestInterface $request,
     Psr\Http\Message\ResponseInterface $response,
     callable $next = null
 ) {
@@ -175,7 +181,7 @@ Error handler middleware has the following signature:
 ```php
 function (
     $error, // Can be any type
-    Psr\Http\Message\RequestInterface $request,
+    Psr\Http\Message\IncomingRequestInterface $request,
     Psr\Http\Message\ResponseInterface $response,
     callable $next
 ) {
@@ -186,7 +192,7 @@ Another approach is to extend the `Phly\Conduit\Middleware` class itself -- part
 
 ```php
 use Phly\Conduit\Middleware;
-use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\IncomingRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
 class CustomMiddleware extends Middleware
@@ -232,14 +238,14 @@ The following make up the primary API of Conduit.
 
 ### Middleware
 
-`Phly\Conduit\Middleware` is the primary application interface, and has been discussed previously. It's API is:
+`Phly\Conduit\Middleware` is the primary application interface, and has been discussed previously. Its API is:
 
 ```php
 class Middleware
 {
     public function pipe($path, $handler = null);
     public function handle(
-        Psr\Http\Message\RequestInterface $request = null,
+        Psr\Http\Message\IncomingRequestInterface $request = null,
         Psr\Http\Message\ResponseInterface $response = null,
         callable $out = null
     );
@@ -265,7 +271,7 @@ Handlers are executed in the order in which they are piped to the `Middleware` i
 
 #### Phly\Conduit\Http\Request
 
-`Phly\Conduit\Http\Request` acts as a decorator for a `Psr\Http\Message\RequestInterface` instance, and implements property overloading, allowing the developer to set and retrieve arbitrary properties other than those exposed via getters. This allows the ability to pass values between handlers.
+`Phly\Conduit\Http\Request` acts as a decorator for a `Psr\Http\Message\IncomingRequestInterface` instance, and implements property overloading, allowing the developer to set and retrieve arbitrary properties other than those exposed via getters. This allows the ability to pass values between handlers.
 
 #### Phly\Conduit\Http\Response
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require": {
     "php": ">=5.4.8",
     "phly/http": "~1.0-dev@dev",
-    "psr/http-message": "~0.2.0@dev",
+    "psr/http-message": "~0.3.0@dev",
     "zendframework/zend-escaper": "~2.3@stable"
   },
   "require-dev": {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -2,18 +2,18 @@
 namespace Phly\Conduit\Http;
 
 use ArrayObject;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\IncomingRequestInterface;
 use Psr\Http\Message\StreamableInterface;
 
 /**
- * Decorator for PSR RequestInterface
+ * Decorator for PSR IncomingRequestInterface
  *
- * Decorates the PSR request interface to add the ability to manipulate
- * arbitrary instance members.
+ * Decorates the PSR incoming request interface to add the ability to 
+ * manipulate arbitrary instance members.
  *
  * @property \Phly\Http\Uri $originalUrl Original URL of this instance
  */
-class Request implements RequestInterface
+class Request implements IncomingRequestInterface
 {
     /**
      * User request parameters
@@ -23,14 +23,14 @@ class Request implements RequestInterface
     private $params = array();
 
     /**
-     * @var RequestInterface
+     * @var IncomingRequestInterface
      */
     private $psrRequest;
 
     /**
-     * @param RequestInterface $request
+     * @param IncomingRequestInterface $request
      */
-    public function __construct(RequestInterface $request)
+    public function __construct(IncomingRequestInterface $request)
     {
         $this->psrRequest = $request;
         $this->originalUrl = $request->getUrl();
@@ -39,7 +39,7 @@ class Request implements RequestInterface
     /**
      * Return the original PSR request object
      *
-     * @return RequestInterface
+     * @return IncomingRequestInterface
      */
     public function getOriginalRequest()
     {
@@ -101,7 +101,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getProtocolVersion()
+     * Proxy to IncomingRequestInterface::getProtocolVersion()
      *
      * @return string HTTP protocol version.
      */
@@ -111,7 +111,18 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getBody()
+     * Proxy to IncomingRequestInterface::setProtocolVersion()
+     * 
+     * @param string $version 
+     * @return void
+     */
+    public function setProtocolVersion($version)
+    {
+        return $this->psrRequest->setProtocolVersion($version);
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::getBody()
      *
      * @return StreamableInterface|null Returns the body, or null if not set.
      */
@@ -121,7 +132,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::setBody()
+     * Proxy to IncomingRequestInterface::setBody()
      *
      * @param StreamableInterface|null $body Body.
      * @throws \InvalidArgumentException When the body is not valid.
@@ -132,7 +143,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getHeaders()
+     * Proxy to IncomingRequestInterface::getHeaders()
      *
      * @return array Returns an associative array of the message's headers.
      */
@@ -142,7 +153,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::hasHeader()
+     * Proxy to IncomingRequestInterface::hasHeader()
      *
      * @param string $header Case-insensitive header name.
      * @return bool Returns true if any header names match the given header
@@ -155,7 +166,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getHeader()
+     * Proxy to IncomingRequestInterface::getHeader()
      *
      * @param string $header Case-insensitive header name.
      * @return string
@@ -166,7 +177,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getHeaderAsArray()
+     * Proxy to IncomingRequestInterface::getHeaderAsArray()
      *
      * @param string $header Case-insensitive header name.
      * @return string[]
@@ -177,7 +188,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::setHeader()
+     * Proxy to IncomingRequestInterface::setHeader()
      *
      * @param string $header Header name
      * @param string|string[] $value  Header value(s)
@@ -188,7 +199,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::setHeaders()
+     * Proxy to IncomingRequestInterface::setHeaders()
      *
      * @param array $headers Headers to set.
      */
@@ -198,7 +209,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::addHeader()
+     * Proxy to IncomingRequestInterface::addHeader()
      *
      * @param string $header Header name to add
      * @param string $value  Value of the header
@@ -209,7 +220,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::addHeaders()
+     * Proxy to IncomingRequestInterface::addHeaders()
      *
      * @param array $headers Associative array of headers to add to the message
      */
@@ -219,7 +230,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::removeHeader()
+     * Proxy to IncomingRequestInterface::removeHeader()
      *
      * @param string $header HTTP header to remove
      */
@@ -229,7 +240,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getMethod()
+     * Proxy to IncomingRequestInterface::getMethod()
      *
      * @return string Returns the request method.
      */
@@ -239,7 +250,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::setMethod()
+     * Proxy to IncomingRequestInterface::setMethod()
      *
      * @param string $method Case-insensitive method.
      */
@@ -249,7 +260,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::getUrl()
+     * Proxy to IncomingRequestInterface::getUrl()
      *
      * @return string|object Returns the URL as a string, or an object that
      *    implements the `__toString()` method. The URL must be an absolute URI
@@ -262,7 +273,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * Proxy to RequestInterface::setUrl()
+     * Proxy to IncomingRequestInterface::setUrl()
      *
      * Also sets originalUrl property if not previously set.
      *
@@ -277,5 +288,96 @@ class Request implements RequestInterface
         if (! $this->originalUrl) {
             $this->originalUrl = $this->psrRequest->getUrl();
         }
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::getCookies()
+     *
+     * @return array|ArrayAccess
+     */
+    public function getCookieParams()
+    {
+        return $this->psrRequest->getCookieParams();
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::setCookies()
+     * 
+     * @param array|ArrayAccess $cookies Cookie values/structs
+     * @return void
+     */
+    public function setCookieParams($cookies)
+    {
+        return $this->psrRequest->setCookieParams($cookies);
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::getQueryParams()
+     * 
+     * @return array|ArrayAccess
+     */
+    public function getQueryParams()
+    {
+        return $this->psrRequest->getQueryParams();
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::getFileParams
+     * 
+     * @return array|ArrayAccess Upload file(s) metadata, if any.
+     */
+    public function getFileParams()
+    {
+        return $this->psrRequest->getFileParams();
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::getBodyParams()
+     *
+     * 
+     * @return array|object The deserialized body parameters, if any. These may
+     *                      be either an array or an object, though an array or
+     *                      array-like object is recommended.
+     */
+    public function getBodyParams()
+    {
+        return $this->psrRequest->getBodyParams();
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::setBodyParams()
+     *
+     * @param array|object $values The deserialized body parameters, if any.
+     *                             These may be either an array or an object,
+     *                             though an array or array-like object is
+     *                             recommended.
+     *
+     * @return void
+     */
+    public function setBodyParams($values)
+    {
+        return $this->psrRequest->setBodyParams($values);
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::getPathParams()
+     *
+     * @return array|ArrayAccess Path parameters matched by routing
+     */
+    public function getPathParams()
+    {
+        return $this->psrRequest->getPathParams();
+    }
+
+    /**
+     * Proxy to IncomingRequestInterface::setPathParams()
+     *
+     * @param array|ArrayAccess $values Path parameters matched by routing
+     *
+     * @return void
+     */
+    public function setPathParams(array $values)
+    {
+        return $this->psrRequest->setPathParams($values);
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -95,7 +95,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::
+     * Proxy to BaseResponseInterface::getProtocolVersion()
      *
      * @return string HTTP protocol version.
      */
@@ -105,7 +105,18 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::getBody()
+     * Proxy to BaseResponseInterface::setProtocolVersion()
+     * 
+     * @param string $version 
+     * @return void
+     */
+    public function setProtocolVersion($version)
+    {
+        return $this->psrResponse->setProtocolVersion($version);
+    }
+
+    /**
+     * Proxy to BaseResponseInterface::getBody()
      *
      * @return StreamableInterface|null Returns the body, or null if not set.
      */
@@ -115,7 +126,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::setBody()
+     * Proxy to BaseResponseInterface::setBody()
      *
      * @param StreamableInterface|null $body Body.
      * @throws \InvalidArgumentException When the body is not valid.
@@ -130,7 +141,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::getHeaders()
+     * Proxy to BaseResponseInterface::getHeaders()
      *
      * @return array Returns an associative array of the message's headers.
      */
@@ -140,7 +151,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::hasHeader()
+     * Proxy to BaseResponseInterface::hasHeader()
      *
      * @param string $header Case-insensitive header name.
      * @return bool Returns true if any header names match the given header
@@ -153,7 +164,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::getHeader()
+     * Proxy to BaseResponseInterface::getHeader()
      *
      * @param string $header Case-insensitive header name.
      * @return string
@@ -164,7 +175,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::getHeaderAsArray()
+     * Proxy to BaseResponseInterface::getHeaderAsArray()
      *
      * @param string $header Case-insensitive header name.
      * @return string[]
@@ -175,7 +186,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::setHeader()
+     * Proxy to BaseResponseInterface::setHeader()
      *
      * @param string $header Header name
      * @param string|string[] $value  Header value(s)
@@ -190,7 +201,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::setHeaders()
+     * Proxy to BaseResponseInterface::setHeaders()
      *
      * @param array $headers Headers to set.
      */
@@ -204,7 +215,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::addHeader()
+     * Proxy to BaseResponseInterface::addHeader()
      *
      * @param string $header Header name to add
      * @param string $value  Value of the header
@@ -219,7 +230,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::addHeaders()
+     * Proxy to BaseResponseInterface::addHeaders()
      *
      * @param array $headers Associative array of headers to add to the message
      */
@@ -233,7 +244,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::removeHeader()
+     * Proxy to BaseResponseInterface::removeHeader()
      *
      * @param string $header HTTP header to remove
      */
@@ -247,7 +258,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::getStatusCode()
+     * Proxy to BaseResponseInterface::getStatusCode()
      *
      * @return integer Status code.
      */
@@ -257,7 +268,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::setStatusCode()
+     * Proxy to BaseResponseInterface::setStatusCode()
      *
      * @param integer $code The 3-digit integer result code to set.
      */
@@ -271,7 +282,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::getReasonPhrase()
+     * Proxy to BaseResponseInterface::getReasonPhrase()
      *
      * @return string|null Reason phrase, or null if unknown.
      */
@@ -281,7 +292,7 @@ class Response implements
     }
 
     /**
-     * Proxy to ResponseInterface::setReasonPhrase()
+     * Proxy to BaseResponseInterface::setReasonPhrase()
      *
      * @param string $phrase The Reason-Phrase to set.
      */

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -4,7 +4,7 @@ namespace Phly\Conduit;
 use ArrayObject;
 use InvalidArgumentException;
 use Phly\Http\Uri;
-use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\IncomingRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
 /**

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -5,7 +5,7 @@ use Exception;
 use Phly\Conduit\FinalHandler;
 use Phly\Conduit\Http\Request;
 use Phly\Conduit\Http\Response;
-use Phly\Http\Request as PsrRequest;
+use Phly\Http\IncomingRequest as PsrRequest;
 use Phly\Http\Response as PsrResponse;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Escaper\Escaper;
@@ -15,7 +15,7 @@ class FinalHandlerTest extends TestCase
     public function setUp()
     {
         $this->escaper  = new Escaper();
-        $this->request  = new Request(new PsrRequest('1.1', 'php://memory'));
+        $this->request  = new Request(new PsrRequest('php://memory'));
         $this->response = new Response(new PsrResponse());
         $this->final    = new FinalHandler($this->request, $this->response);
     }

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -2,7 +2,7 @@
 namespace PhlyTest\Conduit\Http;
 
 use Phly\Conduit\Http\Request;
-use Phly\Http\Request as PsrRequest;
+use Phly\Http\IncomingRequest as PsrRequest;
 use Phly\Http\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
 

--- a/test/MiddlewareTest.php
+++ b/test/MiddlewareTest.php
@@ -5,7 +5,7 @@ use Phly\Conduit\Http\Request as RequestDecorator;
 use Phly\Conduit\Http\Response as ResponseDecorator;
 use Phly\Conduit\Middleware;
 use Phly\Conduit\Utils;
-use Phly\Http\Request;
+use Phly\Http\IncomingRequest as Request;
 use Phly\Http\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
@@ -14,7 +14,7 @@ class MiddlewareTest extends TestCase
 {
     public function setUp()
     {
-        $this->request    = new Request('1.1', 'php://memory');
+        $this->request    = new Request('php://memory');
         $this->response   = new Response();
         $this->middleware = new Middleware();
     }

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -6,7 +6,7 @@ use Phly\Conduit\Http\Request;
 use Phly\Conduit\Http\Response;
 use Phly\Conduit\Next;
 use Phly\Conduit\Route;
-use Phly\Http\Request as PsrRequest;
+use Phly\Http\IncomingRequest as PsrRequest;
 use Phly\Http\Response as PsrResponse;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -15,7 +15,7 @@ class NextTest extends TestCase
     public function setUp()
     {
         $this->stack    = new ArrayObject();
-        $this->request  = new Request(new PsrRequest('1.1', 'php://memory'));
+        $this->request  = new Request(new PsrRequest('php://memory'));
         $this->response = new Response(new PsrResponse());
     }
 


### PR DESCRIPTION
This changeset updates Conduit to psr/http-message 0.3.0 and phly/http 0.5.0. 
The primary changes include:
- Typehinting against `Psr\Http\Message\IncomingRequestInterface` instead of
  `Psr\Http\Message\RequestInterface`. This should not affect existing
  consumers, unless they are extending `Phly\Conduit\Middleware` and overriding
  the `__invoke()` method.
- Adding `setProtocolVersion()` to each of `Phly\Conduit\Http\Request` and
  `Phly\Conduit\Http\Response`.
- Adding the new methods defined in
  `Psr\Http\Message\IncomingRequestInterface`
  to `Phly\Conduit\Http\Request`.

Documentation and tests have all been updated to reflect the above changes.
