### PR TITLE
Update to psr/http-message 0.4.0 && phly/http 0.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": "~0.5.0@dev",
-    "psr/http-message": "~0.3.0@dev",
+    "phly/http": "~0.6.0@dev",
+    "psr/http-message": "~0.4.0@dev",
     "zendframework/zend-escaper": "~2.3@stable"
   },
   "require-dev": {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -199,34 +199,14 @@ class Request implements IncomingRequestInterface
     }
 
     /**
-     * Proxy to IncomingRequestInterface::setHeaders()
-     *
-     * @param array $headers Headers to set.
-     */
-    public function setHeaders(array $headers)
-    {
-        return $this->psrRequest->setHeaders($headers);
-    }
-
-    /**
      * Proxy to IncomingRequestInterface::addHeader()
      *
-     * @param string $header Header name to add
-     * @param string $value  Value of the header
+     * @param string $header Header name to add or append
+     * @param string|string[] $value Value(s) to add or merge into the header
      */
     public function addHeader($header, $value)
     {
         return $this->psrRequest->addHeader($header, $value);
-    }
-
-    /**
-     * Proxy to IncomingRequestInterface::addHeaders()
-     *
-     * @param array $headers Associative array of headers to add to the message
-     */
-    public function addHeaders(array $headers)
-    {
-        return $this->psrRequest->addHeaders($headers);
     }
 
     /**
@@ -277,9 +257,9 @@ class Request implements IncomingRequestInterface
      *
      * Also sets originalUrl property if not previously set.
      *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param string|object $url Request URL.
      * @throws \InvalidArgumentException If the URL is invalid.
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
      */
     public function setUrl($url)
     {
@@ -293,7 +273,7 @@ class Request implements IncomingRequestInterface
     /**
      * Proxy to IncomingRequestInterface::getCookies()
      *
-     * @return array|ArrayAccess
+     * @return array
      */
     public function getCookieParams()
     {
@@ -303,10 +283,9 @@ class Request implements IncomingRequestInterface
     /**
      * Proxy to IncomingRequestInterface::setCookies()
      * 
-     * @param array|ArrayAccess $cookies Cookie values/structs
-     * @return void
+     * @param array $cookies Cookie values/structs
      */
-    public function setCookieParams($cookies)
+    public function setCookieParams(array $cookies)
     {
         return $this->psrRequest->setCookieParams($cookies);
     }
@@ -314,7 +293,7 @@ class Request implements IncomingRequestInterface
     /**
      * Proxy to IncomingRequestInterface::getQueryParams()
      * 
-     * @return array|ArrayAccess
+     * @return array
      */
     public function getQueryParams()
     {
@@ -324,7 +303,7 @@ class Request implements IncomingRequestInterface
     /**
      * Proxy to IncomingRequestInterface::getFileParams
      * 
-     * @return array|ArrayAccess Upload file(s) metadata, if any.
+     * @return array Upload file(s) metadata, if any.
      */
     public function getFileParams()
     {
@@ -335,9 +314,7 @@ class Request implements IncomingRequestInterface
      * Proxy to IncomingRequestInterface::getBodyParams()
      *
      * 
-     * @return array|object The deserialized body parameters, if any. These may
-     *                      be either an array or an object, though an array or
-     *                      array-like object is recommended.
+     * @return array The deserialized body parameters, if any.
      */
     public function getBodyParams()
     {
@@ -347,37 +324,30 @@ class Request implements IncomingRequestInterface
     /**
      * Proxy to IncomingRequestInterface::setBodyParams()
      *
-     * @param array|object $values The deserialized body parameters, if any.
-     *                             These may be either an array or an object,
-     *                             though an array or array-like object is
-     *                             recommended.
-     *
-     * @return void
+     * @param array $values The deserialized body parameters, if any.
      */
-    public function setBodyParams($values)
+    public function setBodyParams(array $values)
     {
         return $this->psrRequest->setBodyParams($values);
     }
 
     /**
-     * Proxy to IncomingRequestInterface::getPathParams()
+     * Proxy to IncomingRequestInterface::getAttributes()
      *
-     * @return array|ArrayAccess Path parameters matched by routing
+     * @return array Attributes derived from the request
      */
-    public function getPathParams()
+    public function getAttributes()
     {
-        return $this->psrRequest->getPathParams();
+        return $this->psrRequest->getAttributes();
     }
 
     /**
-     * Proxy to IncomingRequestInterface::setPathParams()
+     * Proxy to IncomingRequestInterface::setAttributes()
      *
-     * @param array|ArrayAccess $values Path parameters matched by routing
-     *
-     * @return void
+     * @param array Attributes derived from the request
      */
-    public function setPathParams(array $values)
+    public function setAttributes(array $values)
     {
-        return $this->psrRequest->setPathParams($values);
+        return $this->psrRequest->setAttributes($values);
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -201,24 +201,10 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::setHeaders()
-     *
-     * @param array $headers Headers to set.
-     */
-    public function setHeaders(array $headers)
-    {
-        if ($this->complete) {
-            return;
-        }
-
-        return $this->psrResponse->setHeaders($headers);
-    }
-
-    /**
      * Proxy to BaseResponseInterface::addHeader()
      *
-     * @param string $header Header name to add
-     * @param string $value  Value of the header
+     * @param string $header Header name to add or append
+     * @param string|string[] $value Value(s) to add or merge into the header
      */
     public function addHeader($header, $value)
     {
@@ -227,20 +213,6 @@ class Response implements
         }
 
         return $this->psrResponse->addHeader($header, $value);
-    }
-
-    /**
-     * Proxy to BaseResponseInterface::addHeaders()
-     *
-     * @param array $headers Associative array of headers to add to the message
-     */
-    public function addHeaders(array $headers)
-    {
-        if ($this->complete) {
-            return;
-        }
-
-        return $this->psrResponse->addHeaders($headers);
     }
 
     /**

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -68,12 +68,6 @@ class RequestTest extends TestCase
 
         $this->assertSame($this->original->getHeaders(), $this->request->getHeaders());
 
-        $this->request->setHeaders([
-            'Accept'       => 'application/json',
-            'Content-Type' => 'application/json',
-        ]);
-        $this->assertSame($this->original->getHeaders(), $this->request->getHeaders());
-
         $this->request->setHeader('Accept', 'application/xml');
         $this->assertTrue($this->request->hasHeader('Accept'));
         $this->assertEquals('application/xml', $this->request->getHeader('Accept'));
@@ -81,16 +75,7 @@ class RequestTest extends TestCase
         $this->request->addHeader('X-URL', 'http://example.com/foo');
         $this->assertTrue($this->request->hasHeader('X-URL'));
 
-        $this->request->addHeaders([
-            'X-Url'  => 'http://example.com/bar',
-            'X-Flag' => 'true',
-        ]);
-        $this->assertEquals('http://example.com/foo,http://example.com/bar', $this->request->getHeader('X-URL'));
-        $this->assertTrue($this->request->hasHeader('X-Flag'));
-        $this->assertTrue($this->request->hasHeader('Accept'));
-        $this->assertTrue($this->request->hasHeader('Content-Type'));
-
-        $this->request->removeHeader('X-Flag');
-        $this->assertFalse($this->request->hasHeader('X-Flag'));
+        $this->request->removeHeader('X-URL');
+        $this->assertFalse($this->request->hasHeader('X-URL'));
     }
 }

--- a/test/Http/ResponseTest.php
+++ b/test/Http/ResponseTest.php
@@ -61,28 +61,10 @@ class ResponseTest extends TestCase
         $this->assertEquals('foo', (string) $this->response->getBody());
     }
 
-    public function testSetHeadersDoesNothingIfComplete()
-    {
-        $this->response->end('foo');
-        $this->response->setHeaders([
-            'Content-Type' => 'application/json',
-        ]);
-        $this->assertFalse($this->response->hasHeader('Content-Type'));
-    }
-
     public function testAddHeaderDoesNothingIfComplete()
     {
         $this->response->end('foo');
         $this->response->addHeader('Content-Type', 'application/json');
-        $this->assertFalse($this->response->hasHeader('Content-Type'));
-    }
-
-    public function testAddHeadersDoesNothingIfComplete()
-    {
-        $this->response->end('foo');
-        $this->response->addHeaders([
-            'Content-Type' => 'application/json',
-        ]);
         $this->assertFalse($this->response->hasHeader('Content-Type'));
     }
 
@@ -108,12 +90,6 @@ class ResponseTest extends TestCase
 
         $this->assertSame($this->original->getHeaders(), $this->response->getHeaders());
 
-        $this->response->setHeaders([
-            'Accept'       => 'application/json',
-            'Content-Type' => 'application/json',
-        ]);
-        $this->assertSame($this->original->getHeaders(), $this->response->getHeaders());
-
         $this->response->setHeader('Accept', 'application/xml');
         $this->assertTrue($this->response->hasHeader('Accept'));
         $this->assertEquals('application/xml', $this->response->getHeader('Accept'));
@@ -121,17 +97,8 @@ class ResponseTest extends TestCase
         $this->response->addHeader('X-URL', 'http://example.com/foo');
         $this->assertTrue($this->response->hasHeader('X-URL'));
 
-        $this->response->addHeaders([
-            'X-Url'  => 'http://example.com/bar',
-            'X-Flag' => 'true',
-        ]);
-        $this->assertEquals('http://example.com/foo,http://example.com/bar', $this->response->getHeader('X-URL'));
-        $this->assertTrue($this->response->hasHeader('X-Flag'));
-        $this->assertTrue($this->response->hasHeader('Accept'));
-        $this->assertTrue($this->response->hasHeader('Content-Type'));
-
-        $this->response->removeHeader('X-Flag');
-        $this->assertFalse($this->response->hasHeader('X-Flag'));
+        $this->response->removeHeader('X-URL');
+        $this->assertFalse($this->response->hasHeader('X-URL'));
 
         $this->response->setReasonPhrase('FOOBAR');
         $this->assertEquals('FOOBAR', $this->response->getReasonPhrase());


### PR DESCRIPTION
Updates to psr/http-message 0.4.0 and phly/http 0.6.0. These libraries had several BC incompatible changes, requiring changes in Conduit:
- Removal of `setHeaders()` and `addHeaders()` in both the request and response decorators.
- Renaming of `(set|get)PathParams()` to `(set|get)Attributes()` in the request decorator.
- Specifying `array` as the only accepted input type and return type for all `IncomingRequestInterface`-specific methods.
