### PR TITLE
Proxy request properties to attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.8.1 - 2014-11-04
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- `Phly\Conduit\Http\Request` now proxies the property overloading methods to the underlying request's "attributes" methods.
+
 ## 0.8.0 - 2014-11-04
 
 Updates to psr/http-message 0.5.1 and phly/http 0.7.0. These libraries had several BC incompatible changes, requiring BC-breaking changes in Conduit.

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -63,10 +63,7 @@ class Request implements IncomingRequestInterface
      */
     public function __get($name)
     {
-        if (! array_key_exists($name, $this->params)) {
-            return null;
-        }
-        return $this->params[$name];
+        return $this->psrRequest->getAttribute($name);
     }
 
     /**
@@ -80,7 +77,8 @@ class Request implements IncomingRequestInterface
         if (is_array($value)) {
             $value = new ArrayObject($value, ArrayObject::ARRAY_AS_PROPS);
         }
-        $this->params[$name] = $value;
+
+        return $this->psrRequest->setAttribute($name, $value);
     }
 
     /**
@@ -91,7 +89,7 @@ class Request implements IncomingRequestInterface
      */
     public function __isset($name)
     {
-        return array_key_exists($name, $this->params);
+        return (bool) $this->psrRequest->getAttribute($name, false);
     }
 
     /**
@@ -101,10 +99,7 @@ class Request implements IncomingRequestInterface
      */
     public function __unset($name)
     {
-        if (! array_key_exists($name, $this->params)) {
-            return;
-        }
-        unset($this->params[$name]);
+        $this->psrRequest->setAttribute($name, null);
     }
 
     /**

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -85,4 +85,20 @@ class RequestTest extends TestCase
         $this->assertSame($stream, $request->getBody());
         $this->assertSame($psrRequest->getHeaders(), $request->getHeaders());
     }
+
+    public function testPropertyAccessProxiesToRequestAttributes()
+    {
+        $this->original->setAttributes([
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ]);
+
+        $this->assertTrue(isset($this->request->foo));
+        $this->assertTrue(isset($this->request->bar));
+        $this->assertFalse(isset($this->request->baz));
+
+        $this->request->baz = 'quz';
+        $this->assertTrue(isset($this->request->baz));
+        $this->assertEquals('quz', $this->original->getAttribute('baz', false));
+    }
 }


### PR DESCRIPTION
Now that the attributes bucket is in place, the request instance property overloading should proxy to it.
