### PR TITLE
Refactored to use php-fig/fig-standards#400

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": "~0.7.0@dev",
-    "psr/http-message": "~0.5.1@dev",
+    "phly/http": "dev-feature/psr7-full-mutability@dev",
+    "psr/http-message": "dev-feature/full-mutability@dev",
     "zendframework/zend-escaper": "~2.3@stable"
   },
   "require-dev": {
@@ -44,5 +44,15 @@
     "psr-4": {
       "PhlyTest\\Conduit\\": "test/"
     }
-  }
+  },
+  "repositories": [
+    {
+      "url": "git://github.com/weierophinney/http-message.git",
+      "type": "vcs"
+    },
+    {
+      "url": "git://github.com/weierophinney/http.git",
+      "type": "vcs"
+    }
+  ]
 }

--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -88,7 +88,7 @@ class FinalHandler
     {
         $this->response->setStatus(404);
 
-        $url     = $this->request->originalUrl ?: $this->request->getUrl();
+        $url     = $this->request->originalAbsoluteUri ?: $this->request->getAbsoluteUri();
         $escaper = new Escaper();
         $message = sprintf(
             "Cannot %s %s\n",

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,7 +1,7 @@
 <?php
 namespace Phly\Conduit\Http;
 
-use Psr\Http\Message\OutgoingResponseInterface;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Psr\Http\Message\StreamableInterface;
 
 /**
@@ -11,7 +11,7 @@ use Psr\Http\Message\StreamableInterface;
  * to provide a common interface for all PSR HTTP implementations.
  */
 class Response implements
-    OutgoingResponseInterface,
+    PsrResponseInterface,
     ResponseInterface
 {
     /**
@@ -20,14 +20,14 @@ class Response implements
     private $complete = false;
 
     /**
-     * @var BaseResponseInterface
+     * @var PsrResponseInterface
      */
     private $psrResponse;
 
     /**
-     * @param OutgoingResponseInterface $response
+     * @param PsrResponseInterface $response
      */
-    public function __construct(OutgoingResponseInterface $response)
+    public function __construct(PsrResponseInterface $response)
     {
         $this->psrResponse = $response;
     }
@@ -35,7 +35,7 @@ class Response implements
     /**
      * Return the original PSR response object
      *
-     * @return BaseResponseInterface
+     * @return PsrResponseInterface
      */
     public function getOriginalResponse()
     {
@@ -95,7 +95,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getProtocolVersion()
+     * Proxy to PsrResponseInterface::getProtocolVersion()
      *
      * @return string HTTP protocol version.
      */
@@ -105,7 +105,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::setProtocolVersion()
+     * Proxy to PsrResponseInterface::setProtocolVersion()
      * 
      * @param string $version 
      * @return void
@@ -116,7 +116,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getBody()
+     * Proxy to PsrResponseInterface::getBody()
      *
      * @return StreamableInterface|null Returns the body, or null if not set.
      */
@@ -126,7 +126,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::setBody()
+     * Proxy to PsrResponseInterface::setBody()
      *
      * @param StreamableInterface $body Body.
      * @throws \InvalidArgumentException When the body is not valid.
@@ -141,7 +141,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getHeaders()
+     * Proxy to PsrResponseInterface::getHeaders()
      *
      * @return array Returns an associative array of the message's headers.
      */
@@ -151,7 +151,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::hasHeader()
+     * Proxy to PsrResponseInterface::hasHeader()
      *
      * @param string $header Case-insensitive header name.
      * @return bool Returns true if any header names match the given header
@@ -164,7 +164,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getHeader()
+     * Proxy to PsrResponseInterface::getHeader()
      *
      * @param string $header Case-insensitive header name.
      * @return string
@@ -175,18 +175,18 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getHeaderAsArray()
+     * Proxy to PsrResponseInterface::getHeaderAsArray()
      *
      * @param string $header Case-insensitive header name.
      * @return string[]
      */
-    public function getHeaderAsArray($header)
+    public function getHeaderLines($header)
     {
-        return $this->psrResponse->getHeaderAsArray($header);
+        return $this->psrResponse->getHeaderLines($header);
     }
 
     /**
-     * Proxy to BaseResponseInterface::setHeader()
+     * Proxy to PsrResponseInterface::setHeader()
      *
      * @param string $header Header name
      * @param string|string[] $value  Header value(s)
@@ -201,7 +201,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::addHeader()
+     * Proxy to PsrResponseInterface::addHeader()
      *
      * @param string $header Header name to add or append
      * @param string|string[] $value Value(s) to add or merge into the header
@@ -216,7 +216,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::removeHeader()
+     * Proxy to PsrResponseInterface::removeHeader()
      *
      * @param string $header HTTP header to remove
      */
@@ -230,7 +230,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getStatusCode()
+     * Proxy to PsrResponseInterface::getStatusCode()
      *
      * @return integer Status code.
      */
@@ -240,7 +240,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::setStatus()
+     * Proxy to PsrResponseInterface::setStatus()
      *
      * @param integer $code The 3-digit integer result code to set.
      * @param null|string $reasonPhrase The reason phrase to use with the status, if any.
@@ -255,7 +255,7 @@ class Response implements
     }
 
     /**
-     * Proxy to BaseResponseInterface::getReasonPhrase()
+     * Proxy to PsrResponseInterface::getReasonPhrase()
      *
      * @return string|null Reason phrase, or null if unknown.
      */

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -4,8 +4,8 @@ namespace Phly\Conduit;
 use ArrayObject;
 use InvalidArgumentException;
 use Phly\Http\Uri;
-use Psr\Http\Message\IncomingRequestInterface as Request;
-use Psr\Http\Message\OutgoingResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
 
 /**
  * Middleware

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -104,14 +104,14 @@ class FinalHandlerTest extends TestCase
         $this->assertEquals(404, $this->response->getStatusCode());
     }
 
-    public function test404ResponseIncludesOriginalRequestUrl()
+    public function test404ResponseIncludesOriginalRequestAbsoluteUri()
     {
         $originalUrl = 'http://local.example.com/bar/foo';
         $psrRequest = new PsrRequest('php://memory');
         $psrRequest->setMethod('GET');
         $psrRequest->setAbsoluteUri($originalUrl);
         $request = new Request($psrRequest);
-        $request->setUrl('http://local.example.com/foo');
+        $request->setAbsoluteUri('http://local.example.com/foo');
 
         $final = new FinalHandler($request, $this->response);
         call_user_func($final);

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -5,8 +5,8 @@ use Exception;
 use Phly\Conduit\FinalHandler;
 use Phly\Conduit\Http\Request;
 use Phly\Conduit\Http\Response;
-use Phly\Http\IncomingRequest as PsrRequest;
-use Phly\Http\OutgoingResponse as PsrResponse;
+use Phly\Http\ServerRequest as PsrRequest;
+use Phly\Http\Response as PsrResponse;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Escaper\Escaper;
 
@@ -14,8 +14,12 @@ class FinalHandlerTest extends TestCase
 {
     public function setUp()
     {
+        $psrRequest  = new PsrRequest('php://memory');
+        $psrRequest->setMethod('GET');
+        $psrRequest->setAbsoluteUri('http://example.com/');
+
         $this->escaper  = new Escaper();
-        $this->request  = new Request(new PsrRequest('http://example.com/', 'GET', [], 'php://memory'));
+        $this->request  = new Request($psrRequest);
         $this->response = new Response(new PsrResponse());
         $this->final    = new FinalHandler($this->request, $this->response);
     }
@@ -103,12 +107,10 @@ class FinalHandlerTest extends TestCase
     public function test404ResponseIncludesOriginalRequestUrl()
     {
         $originalUrl = 'http://local.example.com/bar/foo';
-        $request = new Request(new PsrRequest(
-            $originalUrl,
-            'GET',
-            [],
-            'php://memory'
-        ));
+        $psrRequest = new PsrRequest('php://memory');
+        $psrRequest->setMethod('GET');
+        $psrRequest->setAbsoluteUri($originalUrl);
+        $request = new Request($psrRequest);
         $request->setUrl('http://local.example.com/foo');
 
         $final = new FinalHandler($request, $this->response);

--- a/test/Http/ResponseTest.php
+++ b/test/Http/ResponseTest.php
@@ -2,7 +2,7 @@
 namespace PhlyTest\Conduit\Http;
 
 use Phly\Conduit\Http\Response;
-use Phly\Http\OutgoingResponse as PsrResponse;
+use Phly\Http\Response as PsrResponse;
 use Phly\Http\Stream;
 use PHPUnit_Framework_TestCase as TestCase;
 

--- a/test/MiddlewareTest.php
+++ b/test/MiddlewareTest.php
@@ -5,8 +5,8 @@ use Phly\Conduit\Http\Request as RequestDecorator;
 use Phly\Conduit\Http\Response as ResponseDecorator;
 use Phly\Conduit\Middleware;
 use Phly\Conduit\Utils;
-use Phly\Http\IncomingRequest as Request;
-use Phly\Http\OutgoingResponse as Response;
+use Phly\Http\ServerRequest as Request;
+use Phly\Http\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
 
@@ -14,12 +14,10 @@ class MiddlewareTest extends TestCase
 {
     public function setUp()
     {
-        $this->request    = new Request(
-            'http://example.com/',
-            'GET',
-            [],
-            'php://memory'
-        );
+        $this->request = new Request('php://memory');
+        $this->request->setMethod('GET');
+        $this->request->setAbsoluteUri('http://example.com/');
+
         $this->response   = new Response();
         $this->middleware = new Middleware();
     }
@@ -64,7 +62,9 @@ class MiddlewareTest extends TestCase
             $phpunit->fail('Should not hit fourth handler!');
         });
 
-        $request = new Request('http://local.example.com/foo', 'GET', [], 'php://memory');
+        $request = new Request('php://memory');
+        $request->setMethod('GET');
+        $request->setAbsoluteUri('http://local.example.com/foo');
         $this->middleware->__invoke($request, $this->response);
         $body = (string) $this->response->getBody();
         $this->assertContains('First', $body);
@@ -92,7 +92,9 @@ class MiddlewareTest extends TestCase
             $phpunit->fail('Should not hit fourth handler!');
         });
 
-        $request = new Request('http://local.example.com/foo', 'GET', [], 'php://memory');
+        $request = new Request('php://memory');
+        $request->setMethod('GET');
+        $request->setAbsoluteUri('http://local.example.com/foo');
         $this->middleware->__invoke($request, $this->response);
         $body = (string) $this->response->getBody();
         $this->assertContains('First', $body);
@@ -117,7 +119,9 @@ class MiddlewareTest extends TestCase
             $next();
         });
 
-        $request = new Request('http://local.example.com/foo', 'GET', [], 'php://memory');
+        $request = new Request('php://memory');
+        $request->setMethod('GET');
+        $request->setAbsoluteUri('http://local.example.com/foo');
         $this->middleware->__invoke($request, $this->response, $out);
         $this->assertTrue($triggered);
     }
@@ -153,7 +157,9 @@ class MiddlewareTest extends TestCase
 
     public function testCanUseDecoratedRequestAndResponseDirectly()
     {
-        $baseRequest = new Request('http://local.example.com/foo', 'GET', [], 'php://memory');
+        $baseRequest = new Request('php://memory');
+        $baseRequest->setMethod('GET');
+        $baseRequest->setAbsoluteUri('http://local.example.com/foo');
 
         $request  = new RequestDecorator($baseRequest);
         $response = new ResponseDecorator($this->response);

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -6,21 +6,20 @@ use Phly\Conduit\Http\Request;
 use Phly\Conduit\Http\Response;
 use Phly\Conduit\Next;
 use Phly\Conduit\Route;
-use Phly\Http\IncomingRequest as PsrRequest;
-use Phly\Http\OutgoingResponse as PsrResponse;
+use Phly\Http\ServerRequest as PsrRequest;
+use Phly\Http\Response as PsrResponse;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class NextTest extends TestCase
 {
     public function setUp()
     {
+        $psrRequest = new PsrRequest('php://memory');
+        $psrRequest->setMethod('GET');
+        $psrRequest->setAbsoluteUri('http://example.com/');
+
         $this->stack    = new ArrayObject();
-        $this->request  = new Request(new PsrRequest(
-            'http://example.com/',
-            'GET',
-            [],
-            'php://memory'
-        ));
+        $this->request  = new Request($psrRequest);
         $this->response = new Response(new PsrResponse());
     }
 


### PR DESCRIPTION
Refactors to use interfaces as defined in linked php-fig pull request,
and as implemented for PR phly/http#18. Since many signatures changed,
particularly request signatures, a number of tests needed to be updated.