### PR TITLE
Fix error handling post-migration to immutable messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.10.0 - TBD
+
+### Added
+
+- `FinalHandler::__invoke`'s signature was modified to require the error
+  argument, as well as a request and response instance. It now also returns a
+  response.
+- `Next::__invoke`'s signature was modified to remove the typehint from the
+  second argument, and to add a third argument, typehinted against
+  `Psr\Http\Message\ResponseInterface`. This change allows passing both an
+  updated request and response in error conditions. It also now passes all three
+  arguments to the final handler.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- `FinalHandler::__construct` removes the arguments representing the request and
+  response instances.
+
+### Fixed
+
+- The changes listed in "Added" and "Removed" fix a condition whereby error
+  handlers were not getting updated response instances, causing those that
+  introspect the response to fail. With the changes, behavior returns to normal.
+
 ## 0.9.1 - 2015-01-19
 
 ### Added

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -68,7 +68,7 @@ class Middleware
         $request  = $this->decorateRequest($request);
         $response = $this->decorateResponse($response);
 
-        $done   = is_callable($out) ? $out : new FinalHandler($request, $response);
+        $done   = is_callable($out) ? $out : new FinalHandler();
         $next   = new Next($this->stack, $request, $response, $done);
         $result = $next();
 

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -230,6 +230,9 @@ class NextTest extends TestCase
         $next();
     }
 
+    /**
+     * @group fail
+     */
     public function testMiddlewareCallingNextWithResponseResetsResponse()
     {
         $phpunit        = $this;
@@ -255,6 +258,9 @@ class NextTest extends TestCase
         $next();
     }
 
+    /**
+     * @group fail
+     */
     public function testNextShouldReturnCurrentResponseAlways()
     {
         $phpunit        = $this;


### PR DESCRIPTION
Following the change to use immutable messages, error handlers largely stopped working. This was due to the fact that they were not receiving the current message instances -- and thus could not pull up-to-date data from them.

This patch does the following:

- `FinalHandler` now no longer accepts the request/response instances to the constructor, but rather expects them to `__invoke` as the second and third methods -- just like normal error middleware, but without the final callable.
- `Next` now passes the current request/response instances to error handlers.
- `Next` now passes the current request/response instances to the final handler.
- `Next` now also allows passing both the request and response when specifying an error.

One upshot: unless you are performing processing AFTER calling `$next()`, you should return its return value to ensure the chain completes properly. This, in the end, is a more functional paradigm, as the chain and application no longer rely on side effects, but explicit return values.