### PR TITLE
[#25] Fix path reset on return from nested middleware

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -139,11 +139,6 @@ class Middleware
      */
     private function normalizePipePath($path)
     {
-        // Strip trailing slash
-        if ('/' === substr($path, -1)) {
-            $path = substr($path, 0, -1);
-        }
-
         // Prepend slash if missing
         if (empty($path) || $path[0] !== '/') {
             $path = '/' . $path;

--- a/test/MiddlewareTest.php
+++ b/test/MiddlewareTest.php
@@ -216,7 +216,7 @@ class MiddlewareTest extends TestCase
         ], 1));
     }
 
-    public function testSlashShouldNotBeAppendedInChildMiddleware()
+    public function testSlashShouldNotBeAppendedInChildMiddlewareWhenLayerDoesNotIncludeIt()
     {
         $this->middleware->pipe('/admin', function ($req, $res, $next) {
             return $next();
@@ -229,5 +229,20 @@ class MiddlewareTest extends TestCase
         $result  = $this->middleware->__invoke($request, $this->response);
         $body    = (string) $result->getBody();
         $this->assertSame('/admin', $body);
+    }
+
+    public function testSlashShouldBeAppendedInChildMiddlewareWhenLayerDoesIncludesIt()
+    {
+        $this->middleware->pipe('/admin/', function ($req, $res, $next) {
+            return $next();
+        });
+        $phpunit = $this;
+        $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
+            return $res->write($req->getUri()->getPath());
+        });
+        $request = new Request([], [], 'http://local.example.com/admin', 'GET', 'php://memory');
+        $result  = $this->middleware->__invoke($request, $this->response);
+        $body    = (string) $result->getBody();
+        $this->assertSame('/admin/', $body);
     }
 }

--- a/test/MiddlewareTest.php
+++ b/test/MiddlewareTest.php
@@ -216,7 +216,7 @@ class MiddlewareTest extends TestCase
         ], 1));
     }
 
-    public function testSlashAppended()
+    public function testSlashShouldNotBeAppendedInChildMiddleware()
     {
         $this->middleware->pipe('/admin', function ($req, $res, $next) {
             return $next();
@@ -227,7 +227,7 @@ class MiddlewareTest extends TestCase
         });
         $request = new Request([], [], 'http://local.example.com/admin', 'GET', 'php://memory');
         $result  = $this->middleware->__invoke($request, $this->response);
-        $body     = (string) $this->response->getBody();
+        $body    = (string) $result->getBody();
         $this->assertSame('/admin', $body);
     }
 }

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -230,9 +230,6 @@ class NextTest extends TestCase
         $next();
     }
 
-    /**
-     * @group fail
-     */
     public function testMiddlewareCallingNextWithResponseResetsResponse()
     {
         $phpunit        = $this;
@@ -258,9 +255,6 @@ class NextTest extends TestCase
         $next();
     }
 
-    /**
-     * @group fail
-     */
     public function testNextShouldReturnCurrentResponseAlways()
     {
         $phpunit        = $this;


### PR DESCRIPTION
This is a patch for #25. It updates the test suite to test for both:

- Routes that had a trailing slash.
- Routes that did not have a trailing slash.

and ensure that:

- Routing works with or without the trailing slash.
- The request URI path is reset to what was specified in the original route.