### PR TITLE
Fix #27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": ">=0.8.2,<0.9.0",
+    "phly/http": ">=0.8.3,<0.9.0",
     "psr/http-message": "~0.6.0",
     "zendframework/zend-escaper": "~2.3@stable"
   },


### PR DESCRIPTION
Issue #27 provides a test that shows another case when trailing slashes are not
handled correctly. The primary fix for this issue comes from phly/http#23, but
this patch also provides a few semantic changes that should ensure all cases
are handled correctly going forward.