### PR TITLE
[WIP] MiddlewareQueue and middleware interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.11.0 - TBD
+
+This release makes several backwards-incompatible changes.
+
+- `Middleware` was renamed to `MiddlewarePipe`. Otherwise, the behavior is
+  exactly the same.
+- `Next` was rewritten to have a consistent invocable signature: 
+  `function (ServerRequestInterface $request, ResponseInterface $response, $err = null)`
+  This change simplifies the logic, removes bugs caused by edge cases, and leads
+  to consistent usage that's easier to remember.
+
+### Added
+
+- `Phly\Conduit\MiddlewareInterface`, which provides an interface to typehint
+  against for middleware. It's usage is not enforced (only a callable is
+  required), but `Phly\Conduit\Dispatch` contains optimizations based on the
+  interface.
+- `Phly\Conduit\ErrorMiddlewareInterface`, which provides an interface to typehint
+  against for error-handling middleware. It's usage is not enforced (only a
+  callable with arity 4 is required), but `Phly\Conduit\Dispatch` contains
+  optimizations based on the interface.
+- `Phly\Conduit\MiddlewarePipe` (replaces by `Phly\Conduit\Middleware`).
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- `Phly\Conduit\Next::__construct` no longer accepts the `$request` or
+  `$response` arguments, as the values are no longer stored internally.
+- `Phly\Conduit\Middleware` (replaced by `Phly\Conduit\MiddlewarePipe`).
+
+### Fixed
+
+- `MiddlewarePipe` was updated to use an `SplQueue` instance internally for
+  modeling the middleware pipeline.
+
 ## 0.10.2 - 2015-01-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ This release makes several backwards-incompatible changes.
 
 - `MiddlewarePipe` was updated to use an `SplQueue` instance internally for
   modeling the middleware pipeline.
+- Properly fixes problems in `Next` reported in [#25](https://github.com/phly/http/pull/25),
+  [#26](https://github.com/phly/http/pull/26), [#27](https://github.com/phly/http/pull/27),
+  and [#28](https://github.com/phly/http/pull/28), which all revolve around
+  resetting the path when trailing slashes are or are not present.
 
 ## 0.10.2 - 2015-01-21
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Usage
 
 Creating an application consists of 3 steps:
 
-- Create middleware or a middleware queue
+- Create middleware or a middleware pipeline
 - Create a server, using the middleware
 - Instruct the server to listen for a request
 
 ```php
-use Phly\Conduit\MiddlewareQueue;
+use Phly\Conduit\MiddlewarePipe;
 use Phly\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$app    = new MiddlewareQueue();
+$app    = new MiddlewarePipe();
 $server = Server::createServer($app,
   $_SERVER,
   $_GET,
@@ -66,12 +66,12 @@ What is middleware?
 Middleware is code that exists between the request and response, and which can take the incoming request, perform actions based on it, and either complete the response or pass delegation on to the next middleware in the queue.
 
 ```php
-use Phly\Conduit\MiddlewareQueue;
+use Phly\Conduit\MiddlewarePipe;
 use Phly\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$app    = new MiddlewareQueue();
+$app    = new MiddlewarePipe();
 $server = Server::createServer($app, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
 
 // Landing page
@@ -114,7 +114,7 @@ The handlers in each middleware attached this way will see a URI with that path 
 Within Conduit, middleware can be:
 
 - Any PHP callable that accepts, minimally, a [PSR-7](https://github.com/php-fig/fig-standards/blob/master/proposed/http-message.md) request and a response (in that order), and, optionally, a callable (for invoking the next middleware in the queue, if any).
-- An object implementing `Phly\Conduit\MiddlewareInterface`. `Phly\Conduit\MiddlewareQueue` implements this interface.
+- An object implementing `Phly\Conduit\MiddlewareInterface`. `Phly\Conduit\MiddlewarePipe` implements this interface.
 
 Error Handlers
 --------------
@@ -127,7 +127,7 @@ function ($error, $request, $response, $next) { }
 
 Alternately, you can implement `Phly\Conduit\ErrorMiddlewareInterface`.
 
-When using `MiddlewareQueue`, as the queue is executed, if `$next()` is called with an argument, or if an exception is thrown, middleware will iterate through the queue until the first such error handler is found. That error handler can either complete the request, or itself call `$next()`. **Error handlers that call `$next()` SHOULD call it with the error it received itself, or with another error.**
+When using `MiddlewarePipe`, as the queue is executed, if `$next()` is called with an argument, or if an exception is thrown, middleware will iterate through the queue until the first such error handler is found. That error handler can either complete the request, or itself call `$next()`. **Error handlers that call `$next()` SHOULD call it with the error it received itself, or with another error.**
 
 Error handlers are usually attached at the end of middleware, to prevent attempts at executing non-error-handling middleware, and to ensure they can intercept errors from any other handlers.
 
@@ -160,7 +160,7 @@ Middleware written in this way can be any of the following:
 - Static class methods
 - PHP array callbacks (e.g., `[ $dispatcher, 'dispatch' ]`, where `$dispatcher` is a class instance)
 - Invokable PHP objects (i.e., instances of classes implementing `__invoke()`)
-- Objects implementing `Phly\Conduit\MiddlewareInterface` (including `Phly\Conduit\MiddlewareQueue`)
+- Objects implementing `Phly\Conduit\MiddlewareInterface` (including `Phly\Conduit\MiddlewarePipe`)
 
 In all cases, if you wish to implement typehinting, the signature is:
 
@@ -188,25 +188,25 @@ function (
 Executing and composing middleware
 ----------------------------------
 
-The easiest way to execute middleware is to write closures and attach them to a `Phly\Conduit\MiddlewareQueue` instance. You can nest `MiddlewareQueue` instances to create groups of related middleware, and attach them using a base path so they only execute if that path is matched.
+The easiest way to execute middleware is to write closures and attach them to a `Phly\Conduit\MiddlewarePipe` instance. You can nest `MiddlewarePipe` instances to create groups of related middleware, and attach them using a base path so they only execute if that path is matched.
 
 ```php
-$api = new MiddlewareQueue(); // API middleware collection
+$api = new MiddlewarePipe();  // API middleware collection
 $api->pipe(/* ... */);        // repeat as necessary
 
-$app = new MiddlewareQueue(); // Middleware representing the application
+$app = new MiddlewarePipe();  // Middleware representing the application
 $app->pipe('/api', $api);     // API middleware attached to the path "/api"
 ```
 
 
-Another approach is to extend the `Phly\Conduit\MiddlewareQueue` class itself -- particularly if you want to allow attaching other middleware to your own middleware. In such a case, you will generally override the `__invoke()` method to perform any additional logic you have, and then call on the parent in order to iterate through your stack of middleware:
+Another approach is to extend the `Phly\Conduit\MiddlewarePipe` class itself -- particularly if you want to allow attaching other middleware to your own middleware. In such a case, you will generally override the `__invoke()` method to perform any additional logic you have, and then call on the parent in order to iterate through your stack of middleware:
 
 ```php
-use Phly\Conduit\MiddlewareQueue;
+use Phly\Conduit\MiddlewarePipe;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
-class CustomMiddleware extends MiddlewareQueue
+class CustomMiddleware extends MiddlewarePipe
 {
     public function __invoke(Request $request, Response $response, callable $next = null)
     {
@@ -223,9 +223,9 @@ class CustomMiddleware extends MiddlewareQueue
 Another approach using this method would be to override the constructor to add in specific middleware, perhaps using configuration provided. In this case, make sure to also call `parent::__construct()` to ensure the middleware queue is initialized; I recommend doing this as the first action of the method.
 
 ```php
-use Phly\Conduit\MiddlewareQueue;
+use Phly\Conduit\MiddlewarePipe;
 
-class CustomMiddleware extends MiddlewareQueue
+class CustomMiddleware extends MiddlewarePipe
 {
     public function __construct($configuration)
     {
@@ -249,10 +249,10 @@ The following make up the primary API of Conduit.
 
 ### Middleware
 
-`Phly\Conduit\MiddlewareQueue` is the primary application interface, and has been discussed previously. Its API is:
+`Phly\Conduit\MiddlewarePipe` is the primary application interface, and has been discussed previously. Its API is:
 
 ```php
-class MiddlewareQueue implements MiddlewareInterface
+class MiddlewarePipe implements MiddlewareInterface
 {
     public function pipe($path, $middleware = null);
     public function __invoke(
@@ -265,11 +265,11 @@ class MiddlewareQueue implements MiddlewareInterface
 
 `pipe()` takes up to two arguments. If only one argument is provided, `$middleware` will be assigned that value, and `$path` will be re-assigned to the value `/`; this is an indication that the `$middleware` should be invoked for any path. If `$path` is provided, the `$middleware` will only be executed for that path and any subpaths.
 
-Middleware is executed in the order in which it is piped to the `MiddlewareQueue` instance.
+Middleware is executed in the order in which it is piped to the `MiddlewarePipe` instance.
 
 `__invoke()` is itself middleware. If `$out` is not provided, an instance of `Phly\Conduit\FinalHandler` will be created, and used in the event that the pipe stack is exhausted.
 
-Internally, `MiddlewareQueue` creates an instance of `Phly\Conduit\Next`, feeding it its queue, executes it, and returns a response.
+Internally, `MiddlewarePipe` creates an instance of `Phly\Conduit\Next`, feeding it its queue, executes it, and returns a response.
 
 ### Next
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Usage
 
 Creating an application consists of 3 steps:
 
-- Create middleware
+- Create middleware or a middleware queue
 - Create a server, using the middleware
 - Instruct the server to listen for a request
 
 ```php
-use Phly\Conduit\Middleware;
+use Phly\Conduit\MiddlewareQueue;
 use Phly\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$app    = new Middleware();
+$app    = new MiddlewareQueue();
 $server = Server::createServer($app,
   $_SERVER,
   $_GET,
@@ -63,15 +63,15 @@ Middleware
 
 What is middleware?
 
-Middleware is code that exists between the request and response, and which can take the incoming request, perform actions based on it, and either complete the response or pass delegation on to the next middleware in the stack.
+Middleware is code that exists between the request and response, and which can take the incoming request, perform actions based on it, and either complete the response or pass delegation on to the next middleware in the queue.
 
 ```php
-use Phly\Conduit\Middleware;
+use Phly\Conduit\MiddlewareQueue;
 use Phly\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$app    = new Middleware();
+$app    = new MiddlewareQueue();
 $server = Server::createServer($app, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
 
 // Landing page
@@ -111,6 +111,11 @@ $app->pipe('/files', $filesMiddleware);
 
 The handlers in each middleware attached this way will see a URI with that path segment stripped -- allowing them to be developed separately and re-used under any path you wish.
 
+Within Conduit, middleware can be:
+
+- Any PHP callable that accepts, minimally, a [PSR-7](https://github.com/php-fig/fig-standards/blob/master/proposed/http-message.md) request and a response (in that order), and, optionally, a callable (for invoking the next middleware in the queue, if any).
+- An object implementing `Phly\Conduit\MiddlewareInterface`. `Phly\Conduit\MiddlewareQueue` implements this interface.
+
 Error Handlers
 --------------
 
@@ -120,29 +125,21 @@ To handle errors, you can write middleware that accepts **exactly** four argumen
 function ($error, $request, $response, $next) { }
 ```
 
-As the stack is executed, if `$next()` is called with an argument, or if an exception is thrown, middleware will iterate through the stack until the first such error handler is found. That error handler can either complete the request, or itself call `$next()`. **Error handlers that call `$next()` SHOULD call it with the error it received itself, or with another error.**
+Alternately, you can implement `Phly\Conduit\ErrorMiddlewareInterface`.
+
+When using `MiddlewareQueue`, as the queue is executed, if `$next()` is called with an argument, or if an exception is thrown, middleware will iterate through the queue until the first such error handler is found. That error handler can either complete the request, or itself call `$next()`. **Error handlers that call `$next()` SHOULD call it with the error it received itself, or with another error.**
 
 Error handlers are usually attached at the end of middleware, to prevent attempts at executing non-error-handling middleware, and to ensure they can intercept errors from any other handlers.
 
 Creating Middleware
 -------------------
 
-The easiest way to create middleware is to either instantiate a `Phly\Conduit\Middleware` instance and attach handlers to it. Attach your middleware instance to the primary application when done.
-
-```php
-$api = new Middleware();
-$api->pipe(/* ... */); // repeat as necessary
-
-$app = new Middleware();
-$app->pipe('/api', $api);
-```
-
-Another way to create middleware is to write a callable capable of receiving minimally a request and a response object, and optionally a callback to call the next in the chain. In your middleware callable, you can handle as much or as little of the request as you want -- including delegating to other handlers. If your middleware also accepts a `$next` argument, if it is unable to complete the request, or allows further processing, it can call it to return handling to the parent middleware.
+To create middleware, write a callable capable of receiving minimally a request and a response object, and optionally a callback to call the next in the chain.  In your middleware, you can handle as much or as little of the request as you want -- including delegating to other middleware. If your middleware accepts a third argument, `$next`, if it is unable to complete the request, or allows further processing, it can call it to return handling to the parent middleware.
 
 As an example, consider the following middleware which will use an external router to map the incoming request path to a handler; if unable to map the request, it returns processing to the next middleware.
 
 ```php
-$app->pipe(function ($req, $res, $next) use ($router) {
+function ($req, $res, $next) use ($router) {
     $path = parse_url($req->getUrl(), PHP_URL_PATH);
 
     // Route the path
@@ -153,7 +150,7 @@ $app->pipe(function ($req, $res, $next) use ($router) {
 
     $handler = $route->getHandler();
     return $handler($req, $res, $next);
-});
+}
 ```
 
 Middleware written in this way can be any of the following:
@@ -163,6 +160,7 @@ Middleware written in this way can be any of the following:
 - Static class methods
 - PHP array callbacks (e.g., `[ $dispatcher, 'dispatch' ]`, where `$dispatcher` is a class instance)
 - Invokable PHP objects (i.e., instances of classes implementing `__invoke()`)
+- Objects implementing `Phly\Conduit\MiddlewareInterface` (including `Phly\Conduit\MiddlewareQueue`)
 
 In all cases, if you wish to implement typehinting, the signature is:
 
@@ -175,7 +173,7 @@ function (
 }
 ```
 
-Error handler middleware has the following signature:
+The implementation Conduit offers also allows you to write specialized error handler middleware. The signature is the same as for normal middleware, except that it expects an additional argument prepended to the signature, `$error`.  (Alternately, you can implement `Phly\Conduit\ErrorMiddlewareInterface`.) The signature is:
 
 ```php
 function (
@@ -187,14 +185,28 @@ function (
 }
 ```
 
-Another approach is to extend the `Phly\Conduit\Middleware` class itself -- particularly if you want to allow attaching other middleware to your own middleware. In such a case, you will generally override the `__invoke()` method to perform any additional logic you have, and then call on the parent in order to iterate through your stack of middleware:
+Executing and composing middleware
+----------------------------------
+
+The easiest way to execute middleware is to write closures and attach them to a `Phly\Conduit\MiddlewareQueue` instance. You can nest `MiddlewareQueue` instances to create groups of related middleware, and attach them using a base path so they only execute if that path is matched.
 
 ```php
-use Phly\Conduit\Middleware;
+$api = new MiddlewareQueue(); // API middleware collection
+$api->pipe(/* ... */);        // repeat as necessary
+
+$app = new MiddlewareQueue(); // Middleware representing the application
+$app->pipe('/api', $api);     // API middleware attached to the path "/api"
+```
+
+
+Another approach is to extend the `Phly\Conduit\MiddlewareQueue` class itself -- particularly if you want to allow attaching other middleware to your own middleware. In such a case, you will generally override the `__invoke()` method to perform any additional logic you have, and then call on the parent in order to iterate through your stack of middleware:
+
+```php
+use Phly\Conduit\MiddlewareQueue;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
-class CustomMiddleware extends Middleware
+class CustomMiddleware extends MiddlewareQueue
 {
     public function __invoke(Request $request, Response $response, callable $next = null)
     {
@@ -208,12 +220,12 @@ class CustomMiddleware extends Middleware
 }
 ```
 
-Another approach using this method would be to override the constructor to add in specific middleware, perhaps using configuration provided. In this case, make sure to also call `parent::__construct()` to ensure the middleware stack is initialized; I recommend doing this as the first action of the method.
+Another approach using this method would be to override the constructor to add in specific middleware, perhaps using configuration provided. In this case, make sure to also call `parent::__construct()` to ensure the middleware queue is initialized; I recommend doing this as the first action of the method.
 
 ```php
-use Phly\Conduit\Middleware;
+use Phly\Conduit\MiddlewareQueue;
 
-class CustomMiddleware extends Middleware
+class CustomMiddleware extends MiddlewareQueue
 {
     public function __construct($configuration)
     {
@@ -237,12 +249,12 @@ The following make up the primary API of Conduit.
 
 ### Middleware
 
-`Phly\Conduit\Middleware` is the primary application interface, and has been discussed previously. Its API is:
+`Phly\Conduit\MiddlewareQueue` is the primary application interface, and has been discussed previously. Its API is:
 
 ```php
-class Middleware
+class MiddlewareQueue implements MiddlewareInterface
 {
-    public function pipe($path, $handler = null);
+    public function pipe($path, $middleware = null);
     public function __invoke(
         Psr\Http\Message\ServerRequestInterface $request = null,
         Psr\Http\Message\ResponseInterface $response = null,
@@ -251,11 +263,13 @@ class Middleware
 }
 ```
 
-`pipe()` takes up to two arguments. If only one argument is provided, `$handler` will be assigned that value, and `$path` will be re-assigned to the value `/`; this is an indication that the `$handler` should be invoked for any path. If `$path` is provided, the `$handler` will only be executed for that path and any subpaths.
+`pipe()` takes up to two arguments. If only one argument is provided, `$middleware` will be assigned that value, and `$path` will be re-assigned to the value `/`; this is an indication that the `$middleware` should be invoked for any path. If `$path` is provided, the `$middleware` will only be executed for that path and any subpaths.
 
-Handlers are executed in the order in which they are piped to the `Middleware` instance.
+Middleware is executed in the order in which it is piped to the `MiddlewareQueue` instance.
 
-`__invoke()` is itself a middleware handler. If `$out` is not provided, an instance of `Phly\Conduit\FinalHandler` will be created, and used in the event that the pipe stack is exhausted.
+`__invoke()` is itself middleware. If `$out` is not provided, an instance of `Phly\Conduit\FinalHandler` will be created, and used in the event that the pipe stack is exhausted.
+
+Internally, `MiddlewareQueue` creates an instance of `Phly\Conduit\Next`, feeding it its queue, executes it, and returns a response.
 
 ### Next
 
@@ -263,13 +277,14 @@ Handlers are executed in the order in which they are piped to the `Middleware` i
 
 Because `Psr\Http\Message`'s interfaces are immutable, if you make changes to your Request and/or Response instances, you will have new instances, and will need to make these known to the next middleware in the chain. `Next` allows this by allowing the following argument combinations:
 
-- `Next()` will re-use the currently registered Request and Response instances.
-- `Next(RequestInterface $request)` will register the provided `$request` with itself, and that instance will be used for subsequent invocations.
-- `Next(ResponseInterface $response)` will register the provided `$response` with itself, and that instance will be used for subsequent invocations.  provided `$response` will be returned.
-- `Next(RequestInterface $request, ResponseInterface $response)` will register each of the provided `$request` and `$response` with itself, and those instances will be used for subsequent invocations.
-- If any other argument is provided for the first argument, it is considered the error to report and pass to registered error middleware. If an error provided, the second argument may be either a request instance or a response instance; if the second argument is a request instance, a response instance may be passed as the third argument.
-
-Note: you **can** pass an error as the first argument and a response as the second, and `Next` will reset the response in that condition as well.
+- `Next()`, which will reuse the current request/response values, and which will only invoke non-error middleware.
+- `Next($err)`, which will reuse the current request/response values, and which will only invoke error middleware, using the provided `$err`.
+- `Next($request)`, which will replace the current request instance with the one provided, and only invoke non-error middleware.
+- `Next($response)`, which will replace the current response instance with the one provided, and only invoke non-error middleware.
+- `Next($request, $response)`, which will replace both the current request and response instance with those provided, and only invoke non-error middleware.
+- `Next($err, $request)`, which will replace the current request instance with the one provided, and only invoke error middleware, using the provided `$err`.
+- `Next($err, $response)`, which will replace the current response instance with the one provided, and only invoke error middleware, using the provided `$err`.
+- `Next($err, $request, $response)`, which will replace both the current request and response instance with those provided, and only invoke error middleware, using the provided `$err`.
 
 As examples:
 
@@ -397,12 +412,12 @@ $server = Server::createServer($app2 /* ... */);
 
 In the above, if the URI of the original incoming request is `/root/foo`, what `$fooCallback` will receive is a URI with a past consisting of only `/foo`. This practice ensures that middleware can be nested safely and resolve regardless of the nesting level.
 
-If you want access to the full URI -- for instance, to construct a fully qualified URI to your current middleware -- `Phly\Conduit\Http\Request` contains a method, `getOriginalRequest()`, which will always return the original request provided:
+If you want access to the full URI -- for instance, to construct a fully qualified URI to your current middleware -- `Phly\Conduit\Http\Request` contains a method, `getOriginalRequest()`, which will always return the original request provided to the application:
 
 ```php
 function ($request, $response, $next)
 {
-    $location = $request->getOriginalRequest()->getAbsoluteUri() . '/[:id]';
+    $location = $request->getOriginalRequest()->getUri()->getPath() . '/[:id]';
     $response = $response->setHeader('Location', $location);
     $response = $response->setStatus(302);
     return $response;

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": ">=0.8.3,<0.9.0",
+    "phly/http": ">=0.8.4,<0.9.0",
     "psr/http-message": "~0.6.0",
     "zendframework/zend-escaper": "~2.3@stable"
   },

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -45,9 +45,20 @@ class Dispatch
         Http\Response $response,
         callable $next
     ) {
-        $arity    = Utils::getArity($route->handler);
-        $hasError = (bool) $err;
         $handler  = $route->handler;
+        $hasError = (null !== $err);
+
+        switch (true) {
+            case ($handler instanceof ErrorMiddlewareInterface):
+                $arity = 4;
+                break;
+            case ($handler instanceof MiddlewareInterface):
+                $arity = 3;
+                break;
+            default:
+                $arity = Utils::getArity($handler);
+                break;
+        }
 
         // @todo Trigger event with Route, original URL from request?
 

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -74,6 +74,6 @@ class Dispatch
             $err = $e;
         }
 
-        return $next($err);
+        return $next($request, $response, $err);
     }
 }

--- a/src/ErrorMiddlewareInterface.php
+++ b/src/ErrorMiddlewareInterface.php
@@ -1,0 +1,37 @@
+<?php
+namespace Phly\Conduit;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ * Middleware for handling errors.
+ *
+ * Error middleware is essentially the same as the `MiddlewareInterface`, with
+ * one key distinction: it has an additional argument prepended, representing
+ * an error condition.
+ *
+ * `Next` will skip error middleware if called without an error; conversely,
+ * if called with an error, it will skip normal middleware.
+ *
+ * Error middleware does something with the arguments passed, and then
+ * either returns a response, or calls `$out`, with or without the error.
+ */
+interface ErrorMiddlewareInterface
+{
+    /**
+     * Process an incoming error, along with associated request and response.
+     *
+     * Accepts an error, a server-side request, and a response instance, and
+     * does something with them; if further processing can be done, it can
+     * delegate to `$out`.
+     *
+     * @see MiddlewareInterface
+     * @param mixed $error
+     * @param Request $request
+     * @param Response $response
+     * @param null|callable $out
+     * @return null|Response
+     */
+    public function __invoke($error, Request $request, Response $response, callable $out = null);
+}

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -1,0 +1,50 @@
+<?php
+namespace Phly\Conduit;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ * Middleware.
+ * 
+ * Middleware accepts a request and a response, and optionally a
+ * callback `$out` (called if the middleware wants to allow further
+ * middleware to process the incoming request, or to delegate output to another 
+ * process).
+ *
+ * Middleware that does not need or desire further processing should not
+ * call `$out`, and should usually instead `return $response->end();`.
+ *
+ * For the purposes of Conduit, `$out` is typically one of either an instance
+ * of `Next` or an instance of `FinalHandler`, and, as such, should follow
+ * those calling semantics.
+ */
+interface MiddlewareInterface
+{
+    /**
+     * Process an incoming request and/or response.
+     *
+     * Accepts a server-side request and a response instance, and does
+     * something with them.
+     *
+     * If the response is not complete and/or further processing would not
+     * interfere with the work done in the middleware, or if the middleware
+     * wants to delegate to another process, it can use the `$out` callable
+     * if present.
+     * 
+     * If the middleware does not return a value, execution of the current 
+     * request is considered complete, and the response instance provided will 
+     * be considered the response to return.
+     *
+     * Alternately, the middleware may return a response instance.
+     *
+     * Often, middleware will `return $out();`, with the assumption that a
+     * later middleware will return a response.
+     * 
+     * @param Request $request 
+     * @param Response $response 
+     * @param null|callable $out 
+     * @return null|Response
+     */
+    public function __invoke(Request $request, Response $response, callable $out = null);
+}

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -8,9 +8,9 @@ use Psr\Http\Message\ResponseInterface as Response;
 use SplQueue;
 
 /**
- * Middleware queue
+ * Pipe middleware like unix pipes.
  *
- * This class implements a queue of middleware, which can be attached using
+ * This class implements a pipe-line of middleware, which can be attached using
  * the `pipe()` method, and is itself middleware.
  *
  * The request and response objects are decorated using the Phly\Conduit\Http
@@ -26,12 +26,12 @@ use SplQueue;
  *
  * @see https://github.com/sencha/connect
  */
-class MiddlewareQueue implements MiddlewareInterface
+class MiddlewarePipe implements MiddlewareInterface
 {
     /**
      * @var SplQueue
      */
-    protected $queue;
+    protected $pipeline;
 
     /**
      * Constructor
@@ -40,17 +40,17 @@ class MiddlewareQueue implements MiddlewareInterface
      */
     public function __construct()
     {
-        $this->queue = new SplQueue();
+        $this->pipeline = new SplQueue();
     }
 
     /**
      * Handle a request
      *
-     * Takes the queue, creates a Next handler, and delegates to the
+     * Takes the pipeline, creates a Next handler, and delegates to the
      * Next handler.
      *
      * If $out is a callable, it is used as the "final handler" when
-     * $next has exhausted the queue; otherwise, a FinalHandler instance
+     * $next has exhausted the pipeline; otherwise, a FinalHandler instance
      * is created and passed to $next during initialization.
      *
      * @param Request $request
@@ -64,14 +64,14 @@ class MiddlewareQueue implements MiddlewareInterface
         $response = $this->decorateResponse($response);
 
         $done   = is_callable($out) ? $out : new FinalHandler();
-        $next   = new Next($this->queue, $done);
+        $next   = new Next($this->pipeline, $done);
         $result = $next($request, $response);
 
         return ($result instanceof Response ? $result : $response);
     }
 
     /**
-     * Attach middleware to the queue.
+     * Attach middleware to the pipeline.
      *
      * Each middleware can be associated with a particular path; if that
      * path is matched when that middleware is invoked, it will be processed;
@@ -104,7 +104,7 @@ class MiddlewareQueue implements MiddlewareInterface
             throw new InvalidArgumentException('Middleware must be callable');
         }
 
-        $this->queue->enqueue(new Route(
+        $this->pipeline->enqueue(new Route(
             $this->normalizePipePath($path),
             $middleware
         ));

--- a/src/Next.php
+++ b/src/Next.php
@@ -67,6 +67,33 @@ class Next
     /**
      * Call the next Route in the stack
      *
+     * Next can accept up to 3 arguments, ith the following signatures:
+     *
+     * - `Next()`, which will reuse the current request/response values, and
+     *   which will only invoke non-error middleware.
+     * - `Next($err)`, which will reuse the current request/response values, and
+     *   which will only invoke error middleware, using the provided `$err`.
+     * - `Next($request)`, which will replace the current request instance with
+     *   the one provided, and only invoke non-error middleware.
+     * - `Next($response)`, which will replace the current response instance with
+     *   the one provided, and only invoke non-error middleware.
+     * - `Next($request, $response)`, which will replace both the current
+     *   request and response instance with those provided, and only invoke
+     *   non-error middleware.
+     * - `Next($err, $request)`, which will replace the current request
+     *   instance with the one provided, and only invoke error middleware, using
+     *   the provided `$err`.
+     * - `Next($err, $response)`, which will replace the current response
+     *   instance with the one provided, and only invoke error middleware, using
+     *   the provided `$err`.
+     * - `Next($err, $request, $response)`, which will replace both the current
+     *   request and response instance with those provided, and only invoke
+     *   error middleware, using the provided `$err`.
+     *
+     * Once dispatch is complete, if the result is a response instance, that
+     * value will be returned; otherwise, the currently registered response
+     * instance will be returned.
+     *
      * @param null|ServerRequestInterface|ResponseInterface|mixed $state
      * @param null|ServerRequestInterface|ResponseInterface $response
      * @param null|ResponseInterface $response

--- a/src/Next.php
+++ b/src/Next.php
@@ -130,7 +130,7 @@ class Next
 
         // Strip trailing slash if current path does not contain it and
         // original path did not have it
-        if ('/' !== $path && '/' !== substr($this->removed, -1)) {
+        if ('/' === $path && '/' !== substr($this->removed, -1)) {
             $resetPath = rtrim($resetPath, '/');
         }
 
@@ -172,6 +172,11 @@ class Next
         $uri  = $request->getUri();
         $path = $this->getTruncatedPath($route, $uri->getPath());
         $new  = $uri->withPath($path);
+
+        // Root path of route is treated differently
+        if ($path === '/' && '/' === substr($uri->getPath(), -1)) {
+            $this->removed .= '/';
+        }
 
         return $request->withUri($new);
     }

--- a/src/Next.php
+++ b/src/Next.php
@@ -1,15 +1,15 @@
 <?php
 namespace Phly\Conduit;
 
-use ArrayObject;
 use Phly\Http\Uri;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
+use SplQueue;
 
 /**
- * Iterate a stack of middlewares and execute them
+ * Iterate a queue of middlewares and execute them.
  */
 class Next
 {
@@ -24,9 +24,9 @@ class Next
     private $done;
 
     /**
-     * @var int
+     * @var SplQueue
      */
-    private $index = 0;
+    private $queue;
 
     /**
      * @var string
@@ -34,135 +34,93 @@ class Next
     private $removed = '';
 
     /**
-     * @var Http\Request
-     */
-    private $request;
-
-    /**
-     * @var Http\Response
-     */
-    private $response;
-
-    /**
-     * @var ArrayObject
-     */
-    private $stack;
-
-    /**
-     * @param ArrayObject $stack
-     * @param Http\Request $request
-     * @param Http\Response $response
+     * @param SplQueue $queue
      * @param callable $done
      */
-    public function __construct(ArrayObject $stack, Http\Request $request, Http\Response $response, callable $done)
+    public function __construct(SplQueue $queue, callable $done)
     {
-        $this->dispatch = new Dispatch();
-
-        $this->stack    = $stack;
-        $this->request  = $request;
-        $this->response = $response;
+        $this->queue    = $queue;
         $this->done     = $done;
+
+        $this->dispatch = new Dispatch();
     }
 
     /**
-     * Call the next Route in the stack
+     * Call the next Route in the queue.
      *
-     * Next can accept up to 3 arguments, ith the following signatures:
+     * Next requires that a request and response are provided; these will be
+     * passed to any middleware invoked, including the $done callable, if
+     * invoked.
      *
-     * - `Next()`, which will reuse the current request/response values, and
-     *   which will only invoke non-error middleware.
-     * - `Next($err)`, which will reuse the current request/response values, and
-     *   which will only invoke error middleware, using the provided `$err`.
-     * - `Next($request)`, which will replace the current request instance with
-     *   the one provided, and only invoke non-error middleware.
-     * - `Next($response)`, which will replace the current response instance with
-     *   the one provided, and only invoke non-error middleware.
-     * - `Next($request, $response)`, which will replace both the current
-     *   request and response instance with those provided, and only invoke
-     *   non-error middleware.
-     * - `Next($err, $request)`, which will replace the current request
-     *   instance with the one provided, and only invoke error middleware, using
-     *   the provided `$err`.
-     * - `Next($err, $response)`, which will replace the current response
-     *   instance with the one provided, and only invoke error middleware, using
-     *   the provided `$err`.
-     * - `Next($err, $request, $response)`, which will replace both the current
-     *   request and response instance with those provided, and only invoke
-     *   error middleware, using the provided `$err`.
+     * If the $err value is not null, the invocation is considered to be an
+     * error invocation, and Next will search for the next error middleware
+     * to dispatch, passing it $err along with the request and response.
      *
      * Once dispatch is complete, if the result is a response instance, that
      * value will be returned; otherwise, the currently registered response
      * instance will be returned.
      *
-     * @param null|ServerRequestInterface|ResponseInterface|mixed $state
-     * @param null|ServerRequestInterface|ResponseInterface $response
-     * @param null|ResponseInterface $response
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param null|mixed $err
      * @return ResponseInterface
      */
     public function __invoke(
-        $state = null,
-        MessageInterface $requestOrResponse = null,
-        ResponseInterface $response = null
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        $err = null
     ) {
-        $args         = $this->parseArguments($state, $requestOrResponse, $response);
-        $err          = $args->err;
-        $resetRequest = $args->resetRequest;
-
-
         $dispatch = $this->dispatch;
         $done     = $this->done;
-        $this->resetPath($this->request, $resetRequest);
+        $request  = $this->resetPath($request);
 
         // No middleware remains; done
-        if (! isset($this->stack[$this->index])) {
-            return $done($err, $this->request, $this->response);
+        if ($this->queue->isEmpty()) {
+            return $done($err, $request, $response);
         }
 
-        $layer           = $this->stack[$this->index++];
-        $path            = $this->request->getUri()->getPath() ?: '/';
+        $layer           = $this->queue->dequeue();
+        $path            = $request->getUri()->getPath() ?: '/';
         $route           = $layer->path;
         $normalizedRoute = (strlen($route) > 1) ? rtrim($route, '/') : $route;
 
         // Skip if layer path does not match current url
         if (substr(strtolower($path), 0, strlen($normalizedRoute)) !== strtolower($normalizedRoute)) {
-            return $this($err);
+            return $this($request, $response, $err);
         }
 
         // Skip if match is not at a border ('/', '.', or end)
         $border = $this->getBorder($path, $normalizedRoute);
         if ($border && '/' !== $border && '.' !== $border) {
-            return $this($err);
+            return $this($request, $response, $err);
         }
 
         // Trim off the part of the url that matches the layer route
         if (! empty($route) && $route !== '/') {
-            $this->stripRouteFromPath($route);
+            $request = $this->stripRouteFromPath($request, $route);
         }
 
-        $result = $dispatch($layer, $err, $this->request, $this->response, $this);
-        if ($result instanceof ResponseInterface) {
-            $this->response = $result;
-        }
-        return $this->response;
+        $result = $dispatch($layer, $err, $request, $response, $this);
+
+        return ($result instanceof ResponseInterface ? $result : $response);
     }
 
     /**
      * Reset the path, if a segment was previously stripped
      *
      * @param Http\Request $request
-     * @param bool $resetRequest Whether or not the request was reset in this iteration
+     * @return Http\Request
      */
-    private function resetPath(Http\Request $request, $resetRequest = false)
+    private function resetPath(Http\Request $request)
     {
         if (! $this->removed) {
-            return;
+            return $request;
         }
 
         $uri  = $request->getUri();
         $path = $uri->getPath();
 
-        if ($resetRequest
-            && strlen($path) >= strlen($this->removed)
+        if (strlen($path) >= strlen($this->removed)
             && 0 === strpos($path, $this->removed)
         ) {
             $path = str_replace($this->removed, '', $path);
@@ -181,7 +139,7 @@ class Next
 
         $new  = $uri->withPath($resetPath);
         $this->removed = '';
-        $this->request = $request->withUri($new);
+        return $request->withUri($new);
     }
 
     /**
@@ -203,17 +161,19 @@ class Next
     /**
      * Strip the route from the request path
      *
+     * @param Http\Request $request
      * @param string $route
+     * @return Http\Request
      */
-    private function stripRouteFromPath($route)
+    private function stripRouteFromPath(Http\Request $request, $route)
     {
         $this->removed = $route;
 
-        $uri  = $this->request->getUri();
+        $uri  = $request->getUri();
         $path = $this->getTruncatedPath($route, $uri->getPath());
         $new  = $uri->withPath($path);
 
-        $this->request = $this->request->withUri($new);
+        return $request->withUri($new);
     }
 
     /**
@@ -246,59 +206,5 @@ class Next
         throw new RuntimeException(
             'Layer and request path have gone out of sync'
         );
-    }
-
-    /**
-     * Parse invocation arguments.
-     *
-     * Parses invocation arguments and sets request and/or response properties
-     * as needed.
-     *
-     * @param null|ServerRequestInterface|ResponseInterface|mixed $state
-     * @param null|ServerRequestInterface|ResponseInterface $requestOrResponse
-     * @param null|ResponseInterface $response
-     */
-    private function parseArguments(
-        $state,
-        MessageInterface $requestOrResponse = null,
-        ResponseInterface $response = null
-    ) {
-        $args = (object) [
-            'err'          => null,
-            'resetRequest' => false,
-        ];
-
-        if ($state instanceof ResponseInterface) {
-            $this->response = $state;
-        }
-
-        if ($state instanceof ServerRequestInterface) {
-            $this->request      = $state;
-            $args->resetRequest = true;
-        }
-
-        if ($requestOrResponse instanceof ServerRequestInterface) {
-            $this->request      = $requestOrResponse;
-            $args->resetRequest = true;
-        }
-
-        if ($requestOrResponse instanceof ResponseInterface) {
-            $this->response = $requestOrResponse;
-        }
-
-        if (! $requestOrResponse instanceof ResponseInterface
-            && $response instanceof ResponseInterface
-        ) {
-            $this->response = $response;
-        }
-
-        if (null !== $state
-            && ! $state instanceof ServerRequestInterface
-            && ! $state instanceof ResponseInterface
-        ) {
-            $args->err = $state;
-        }
-
-        return $args;
     }
 }

--- a/test/DispatchTest.php
+++ b/test/DispatchTest.php
@@ -26,7 +26,7 @@ class DispatchTest extends TestCase
         $handler = function ($err, $req, $res, $next) use (&$triggered) {
             $triggered = $err;
         };
-        $next = function ($err) use ($phpunit) {
+        $next = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Next was called; it should not have been');
         };
 
@@ -45,7 +45,7 @@ class DispatchTest extends TestCase
         $handler = function ($req, $res, $next) use ($phpunit) {
             $phpunit->fail('Handler was called; it should not have been');
         };
-        $next = function ($err) use (&$triggered) {
+        $next = function ($req, $res, $err) use (&$triggered) {
             $triggered = $err;
         };
 
@@ -64,7 +64,7 @@ class DispatchTest extends TestCase
         $handler = function ($err, $req, $res, $next) use ($phpunit) {
             $phpunit->fail('Handler was called; it should not have been');
         };
-        $next = function ($err) use (&$triggered) {
+        $next = function ($req, $res, $err) use (&$triggered) {
             $triggered = $err;
         };
 
@@ -83,7 +83,7 @@ class DispatchTest extends TestCase
         $handler = function ($req, $res, $next) use (&$triggered) {
             $triggered = $req;
         };
-        $next = function ($err) use ($phpunit) {
+        $next = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Next was called; it should not have been');
         };
 
@@ -103,7 +103,7 @@ class DispatchTest extends TestCase
         $handler = function ($err, $req, $res, $next) use ($exception) {
             throw $exception;
         };
-        $next = function ($err) use (&$triggered) {
+        $next = function ($req, $res, $err) use (&$triggered) {
             $triggered = $err;
         };
 
@@ -123,7 +123,7 @@ class DispatchTest extends TestCase
         $handler = function ($req, $res, $next) use ($exception) {
             throw $exception;
         };
-        $next = function ($err) use (&$triggered) {
+        $next = function ($req, $res, $err) use (&$triggered) {
             $triggered = $err;
         };
 
@@ -140,7 +140,7 @@ class DispatchTest extends TestCase
         $handler = function ($req, $res, $next) {
             return $res;
         };
-        $next = function ($err) use ($phpunit) {
+        $next = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Next was called; it should not have been');
         };
 
@@ -151,13 +151,13 @@ class DispatchTest extends TestCase
         $this->assertSame($this->response, $result);
     }
 
-    public function testReturnsValueFromErrorHandler()
+    public function testIfErrorHandlerReturnsResponseDispatchReturnsTheResponse()
     {
         $phpunit = $this;
         $handler = function ($err, $req, $res, $next) {
             return $res;
         };
-        $next = function ($err) use ($phpunit) {
+        $next = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Next was called; it should not have been');
         };
 
@@ -166,24 +166,5 @@ class DispatchTest extends TestCase
         $err = (object) ['error' => true];
         $result = $dispatch($route, $err, $this->request, $this->response, $next);
         $this->assertSame($this->response, $result);
-    }
-
-    public function testReturnsValueFromTriggeringNextAfterThrowingExceptionInNonErrorHandler()
-    {
-        $phpunit   = $this;
-        $exception = new RuntimeException;
-
-        $handler = function ($req, $res, $next) use ($exception) {
-            throw $exception;
-        };
-        $next = function ($err) {
-            return $err;
-        };
-
-        $route = new Route('/foo', $handler);
-        $dispatch = new Dispatch();
-        $err = null;
-        $result = $dispatch($route, $err, $this->request, $this->response, $next);
-        $this->assertSame($exception, $result);
     }
 }

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -3,7 +3,7 @@ namespace PhlyTest\Conduit;
 
 use Phly\Conduit\Http\Request as RequestDecorator;
 use Phly\Conduit\Http\Response as ResponseDecorator;
-use Phly\Conduit\MiddlewareQueue;
+use Phly\Conduit\MiddlewarePipe;
 use Phly\Conduit\Utils;
 use Phly\Http\ServerRequest as Request;
 use Phly\Http\Response;
@@ -11,13 +11,13 @@ use Phly\Http\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
 
-class MiddlewareQueueTest extends TestCase
+class MiddlewarePipeTest extends TestCase
 {
     public function setUp()
     {
         $this->request    = new Request([], [], 'http://example.com/', 'GET', 'php://memory');
         $this->response   = new Response();
-        $this->middleware = new MiddlewareQueue();
+        $this->middleware = new MiddlewarePipe();
     }
 
     public function invalidHandlers()

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -246,4 +246,23 @@ class MiddlewarePipeTest extends TestCase
         $body    = (string) $result->getBody();
         $this->assertSame('/admin/', $body);
     }
+
+    public function testSlashShouldBePresentForRootPathsAlways()
+    {
+        $this->middleware->pipe('/', function ($req, $res, $next) {
+            return $next($req, $res);
+        });
+        $phpunit = $this;
+        $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
+            return $res->write($req->getUri()->getPath());
+        });
+
+        // Note: no path present in request
+        $request = new Request([], [], 'http://local.example.com', 'GET', 'php://memory');
+        $result  = $this->middleware->__invoke($request, $this->response);
+        $body    = (string) $result->getBody();
+
+        // Assertion is that absence of path == root path
+        $this->assertSame('/', $body);
+    }
 }

--- a/test/MiddlewareQueueTest.php
+++ b/test/MiddlewareQueueTest.php
@@ -46,11 +46,11 @@ class MiddlewareQueueTest extends TestCase
     {
         $this->middleware->pipe(function ($req, $res, $next) {
             $res->write("First\n");
-            $next();
+            $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
             $res->write("Second\n");
-            $next();
+            $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
             $res->write("Third\n");
@@ -71,10 +71,10 @@ class MiddlewareQueueTest extends TestCase
     public function testHandleInvokesFirstErrorHandlerOnErrorInChain()
     {
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next($res->write("First\n"));
+            $next($req, $res->write("First\n"));
         });
         $this->middleware->pipe(function ($req, $res, $next) {
-            return $next('error');
+            return $next($req, $res, 'error');
         });
         $this->middleware->pipe(function ($req, $res, $next) {
             return $res->write("Third\n");
@@ -103,13 +103,13 @@ class MiddlewareQueueTest extends TestCase
         };
 
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
 
         $request = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
@@ -158,10 +158,10 @@ class MiddlewareQueueTest extends TestCase
     public function testReturnsOrigionalResponseIfQueueDoesNotReturnAResponse()
     {
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
             return;
@@ -181,10 +181,10 @@ class MiddlewareQueueTest extends TestCase
         $return = new Response();
 
         $this->middleware->pipe(function ($req, $res, $next) {
-            $next();
+            return $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) {
-            return $next();
+            return $next($req, $res);
         });
         $this->middleware->pipe(function ($req, $res, $next) use ($return) {
             return $return;
@@ -205,7 +205,7 @@ class MiddlewareQueueTest extends TestCase
     public function testSlashShouldNotBeAppendedInChildMiddlewareWhenLayerDoesNotIncludeIt()
     {
         $this->middleware->pipe('/admin', function ($req, $res, $next) {
-            return $next();
+            return $next($req, $res);
         });
         $phpunit = $this;
         $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
@@ -220,7 +220,7 @@ class MiddlewareQueueTest extends TestCase
     public function testSlashShouldBeAppendedInChildMiddlewareWhenLayerDoesIncludesIt()
     {
         $this->middleware->pipe('/admin/', function ($req, $res, $next) {
-            return $next();
+            return $next($req, $res);
         });
         $phpunit = $this;
         $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
@@ -235,7 +235,7 @@ class MiddlewareQueueTest extends TestCase
     public function testSlashShouldBeAppendedInChildMiddlewareWhenRequestUriIncludesIt()
     {
         $this->middleware->pipe('/admin', function ($req, $res, $next) {
-            return $next();
+            return $next($req, $res);
         });
         $phpunit = $this;
         $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {

--- a/test/MiddlewareQueueTest.php
+++ b/test/MiddlewareQueueTest.php
@@ -117,20 +117,6 @@ class MiddlewareQueueTest extends TestCase
         $this->assertTrue($triggered);
     }
 
-    public function testPipeWillCreateClosureForObjectImplementingHandle()
-    {
-        $handler = new TestAsset\NormalHandler();
-        $this->middleware->pipe($handler);
-        $r = new ReflectionProperty($this->middleware, 'queue');
-        $r->setAccessible(true);
-        $queue = $r->getValue($this->middleware);
-        $route = $queue[$queue->count() - 1];
-        $this->assertInstanceOf('Phly\Conduit\Route', $route);
-        $handler = $route->handler;
-        $this->assertInstanceOf('Closure', $handler);
-        $this->assertEquals(3, Utils::getArity($handler));
-    }
-
     public function testPipeWillCreateErrorClosureForObjectImplementingHandle()
     {
         $this->markTestIncomplete();

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace PhlyTest\Conduit;
 
-use ArrayObject;
 use Phly\Conduit\Http\Request;
 use Phly\Conduit\Http\Response;
 use Phly\Conduit\Next;
@@ -10,13 +9,14 @@ use Phly\Http\ServerRequest as PsrRequest;
 use Phly\Http\Response as PsrResponse;
 use Phly\Http\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
+use SplQueue;
 
 class NextTest extends TestCase
 {
     public function setUp()
     {
         $psrRequest     = new PsrRequest([], [], 'http://example.com/', 'GET', 'php://memory');
-        $this->queue    = new ArrayObject();
+        $this->queue    = new SplQueue();
         $this->request  = new Request($psrRequest);
         $this->response = new Response(new PsrResponse());
     }
@@ -29,8 +29,8 @@ class NextTest extends TestCase
             $triggered = true;
         };
 
-        $next = new Next($this->queue, $this->request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($this->request, $this->response);
         $this->assertTrue($triggered);
     }
 
@@ -41,7 +41,7 @@ class NextTest extends TestCase
         $route = new Route('/foo', function ($req, $res, $next) use ($phpunit) {
             $phpunit->fail('Route should not be invoked if path does not match');
         });
-        $this->queue[] = $route;
+        $this->queue->enqueue($route);
 
         $triggered = null;
         $done = function ($err = null) use (&$triggered) {
@@ -50,8 +50,8 @@ class NextTest extends TestCase
 
         $this->request->withUri(new Uri('http://local.example.com/bar'));
 
-        $next = new Next($this->queue, $this->request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($this->request, $this->response);
         $this->assertTrue($triggered);
     }
 
@@ -62,7 +62,7 @@ class NextTest extends TestCase
         $route = new Route('/foo', function ($req, $res, $next) use ($phpunit) {
             $phpunit->fail('Route should not be invoked if path does not match');
         });
-        $this->queue[] = $route;
+        $this->queue->enqueue($route);
 
         $triggered = null;
         $done = function ($err = null) use (&$triggered) {
@@ -71,8 +71,8 @@ class NextTest extends TestCase
 
         $this->request->withUri(new Uri('http://local.example.com/foobar'));
 
-        $next = new Next($this->queue, $this->request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($this->request, $this->response);
         $this->assertTrue($triggered);
     }
 
@@ -83,7 +83,7 @@ class NextTest extends TestCase
         $route = new Route('/foo', function ($req, $res, $next) use (&$triggered) {
             $triggered = true;
         });
-        $this->queue[] = $route;
+        $this->queue->enqueue($route);
 
         $phpunit = $this;
         $done = function ($err = null) use ($phpunit) {
@@ -92,8 +92,8 @@ class NextTest extends TestCase
 
         $request = $this->request->withUri(new Uri('http://local.example.com/foo'));
 
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($request, $this->response);
         $this->assertTrue($triggered);
     }
 
@@ -105,7 +105,7 @@ class NextTest extends TestCase
         $route = new Route('/foo', function ($req, $res, $next) use (&$triggered) {
             $triggered = $req->getUri()->getPath();
         });
-        $this->queue[] = $route;
+        $this->queue->enqueue($route);
 
         $phpunit = $this;
         $done = function ($err = null) use ($phpunit) {
@@ -114,27 +114,27 @@ class NextTest extends TestCase
 
         $request = $this->request->withUri(new Uri('http://local.example.com/foo/bar'));
 
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($request, $this->response);
         $this->assertEquals('/bar', $triggered);
     }
 
     public function testSlashAndPathGetResetBeforeExecutingNextMiddleware()
     {
         $route1 = new Route('/foo', function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
         $route2 = new Route('/foo/bar', function ($req, $res, $next) {
-            $next();
+            $next($req, $res);
         });
         $route3 = new Route('/foo/baz', function ($req, $res, $next) {
             $res->end('done');
             return $res;
         });
 
-        $this->queue->append($route1);
-        $this->queue->append($route2);
-        $this->queue->append($route3);
+        $this->queue->enqueue($route1);
+        $this->queue->enqueue($route2);
+        $this->queue->enqueue($route3);
 
         $phpunit = $this;
         $done = function ($err) use ($phpunit) {
@@ -142,8 +142,8 @@ class NextTest extends TestCase
         };
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/baz/bat'));
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($request, $this->response);
         $this->assertEquals('done', (string) $this->response->getBody());
     }
 
@@ -154,25 +154,25 @@ class NextTest extends TestCase
             return $res;
         });
         $route2 = new Route('/foo/bar', function ($req, $res, $next) use ($phpunit) {
-            $next();
+            $next($req, $res);
             $phpunit->fail('Should not hit route2 handler');
         });
         $route3 = new Route('/foo/baz', function ($req, $res, $next) use ($phpunit) {
-            $next();
+            $next($req, $res);
             $phpunit->fail('Should not hit route3 handler');
         });
 
-        $this->queue->append($route1);
-        $this->queue->append($route2);
-        $this->queue->append($route3);
+        $this->queue->enqueue($route1);
+        $this->queue->enqueue($route2);
+        $this->queue->enqueue($route3);
 
         $done = function ($err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/bar/baz'));
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $result = $next();
+        $next = new Next($this->queue, $done);
+        $result = $next($request, $this->response);
         $this->assertSame($this->response, $result);
     }
 
@@ -183,28 +183,28 @@ class NextTest extends TestCase
         $triggered = false;
 
         $route1 = new Route('/foo', function ($req, $res, $next) use ($cannedResponse) {
-            return $next($cannedResponse);
+            return $next($req, $cannedResponse);
         });
         $route2 = new Route('/foo/bar', function ($req, $res, $next) use ($phpunit, $cannedResponse, &$triggered) {
             $phpunit->assertSame($cannedResponse, $res);
             $triggered = true;
         });
 
-        $this->queue->append($route1);
-        $this->queue->append($route2);
+        $this->queue->enqueue($route1);
+        $this->queue->enqueue($route2);
 
         $done = function ($err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/bar/baz'));
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $result = $next();
+        $next = new Next($this->queue, $done);
+        $result = $next($request, $this->response);
         $this->assertTrue($triggered);
         $this->assertSame($cannedResponse, $result);
     }
 
-    public function testMiddlewareCallingNextWithRequestResetsRequest()
+    public function testMiddlewareCallingNextWithRequestPassesRequestToNextMiddleware()
     {
         $phpunit       = $this;
         $request       = $this->request->withUri(new Uri('http://example.com/foo/bar/baz'));
@@ -212,22 +212,22 @@ class NextTest extends TestCase
         $cannedRequest = $cannedRequest->withMethod('POST');
 
         $route1 = new Route('/foo/bar', function ($req, $res, $next) use ($cannedRequest) {
-            return $next($cannedRequest);
+            return $next($cannedRequest, $res);
         });
         $route2 = new Route('/foo/bar/baz', function ($req, $res, $next) use ($phpunit, $cannedRequest) {
             $phpunit->assertEquals($cannedRequest->getMethod(), $req->getMethod());
             return $res;
         });
 
-        $this->queue->append($route1);
-        $this->queue->append($route2);
+        $this->queue->enqueue($route1);
+        $this->queue->enqueue($route2);
 
         $done = function ($err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($request, $this->response);
     }
 
     public function testMiddlewareCallingNextWithResponseResetsResponse()
@@ -236,48 +236,48 @@ class NextTest extends TestCase
         $cannedResponse = new Response(new PsrResponse());
 
         $route1 = new Route('/foo', function ($req, $res, $next) use ($cannedResponse) {
-            return $next(null, $cannedResponse);
+            return $next($req, $cannedResponse);
         });
         $route2 = new Route('/foo/bar', function ($req, $res, $next) use ($phpunit, $cannedResponse) {
             $phpunit->assertSame($cannedResponse, $res);
             return $res;
         });
 
-        $this->queue->append($route1);
-        $this->queue->append($route2);
+        $this->queue->enqueue($route1);
+        $this->queue->enqueue($route2);
 
         $done = function ($err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/bar/baz'));
-        $next = new Next($this->queue, $request, $this->response, $done);
-        $next();
+        $next = new Next($this->queue, $done);
+        $next($request, $this->response);
     }
 
-    public function testNextShouldReturnCurrentResponseAlways()
+    public function testNextShouldReturnPassedResponseWhenNoReturnValueProvided()
     {
         $phpunit        = $this;
         $cannedResponse = new Response(new PsrResponse());
 
         $route1 = new Route('/foo', function ($req, $res, $next) use ($cannedResponse) {
-            $next(null, $cannedResponse);
+            $next($req, $cannedResponse);
         });
         $route2 = new Route('/foo/bar', function ($req, $res, $next) use ($phpunit, $cannedResponse) {
             $phpunit->assertSame($cannedResponse, $res);
             return $res;
         });
 
-        $this->queue->append($route1);
-        $this->queue->append($route2);
+        $this->queue->enqueue($route1);
+        $this->queue->enqueue($route2);
 
         $done = function ($err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/bar/baz'));
-        $next    = new Next($this->queue, $request, $this->response, $done);
-        $result  = $next();
-        $this->assertSame($cannedResponse, $result);
+        $next    = new Next($this->queue, $done);
+        $result  = $next($request, $this->response);
+        $this->assertSame($this->response, $result);
     }
 }

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -2,7 +2,7 @@
 namespace PhlyTest\Conduit;
 
 use Phly\Conduit\Dispatch;
-use Phly\Conduit\Middleware;
+use Phly\Conduit\MiddlewareQueue;
 use Phly\Conduit\Utils;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -15,7 +15,7 @@ class UtilsTest extends TestCase
             'closure' => [function ($x, $y) {
             }, 2],
             'invokable' => [new Dispatch(), 5],
-            'handler' => [new Middleware(), 2], // 2 REQUIRED arguments!
+            'interface' => [new MiddlewareQueue(), 2], // 2 REQUIRED arguments!
         ];
     }
 

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -2,7 +2,7 @@
 namespace PhlyTest\Conduit;
 
 use Phly\Conduit\Dispatch;
-use Phly\Conduit\MiddlewareQueue;
+use Phly\Conduit\MiddlewarePipe;
 use Phly\Conduit\Utils;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -15,7 +15,7 @@ class UtilsTest extends TestCase
             'closure' => [function ($x, $y) {
             }, 2],
             'invokable' => [new Dispatch(), 5],
-            'interface' => [new MiddlewareQueue(), 2], // 2 REQUIRED arguments!
+            'interface' => [new MiddlewarePipe(), 2], // 2 REQUIRED arguments!
         ];
     }
 


### PR DESCRIPTION
Semantically, `Middleware` was a queue, so I renamed the class to `MiddlewareQueue`, which required also updating tests.  Additionally, updated the internal variables of `Next` and `MiddlewareQueue` to read "queue" instead of "stack" to reflect their actual semantics.

I've also created `MiddlewareInterface`, to describe normal middleware, and
`ErrorMiddlewareInterface`, to describe middleware for handling errors.
Internally, `Dispatch` will use these to determine the type of middleware
being executed (and fall back to arity if the middleware does not implement
one of them).

By doing this, I also was able to remove the logic for using a "handle"
method, as it no longer needs to be supported.

I've now written all the various signatures `Next()` supports; I'm leaning
towards a required signature at this time, as it's getting too complicated.

**Update:** This PR also incorporates the unified signature for `Next()`:

```php
function (ServerRequestInterface $request, ResponseInterface $response, $err = null);
```

This change means there are only two ways to call `Next()`: with or without an error. It also simplified internal logic dramatically.

Addresses #24 