### PR TITLE
Fix to FinalHandler to use Next signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": ">=0.8.4,<0.9.0",
+    "phly/http": "~0.9.0",
     "psr/http-message": "~0.6.0",
     "zendframework/zend-escaper": "~2.3@stable"
   },

--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -31,12 +31,12 @@ class FinalHandler
      *
      * Otherwise, a 404 status is created.
      *
-     * @param mixed $err
      * @param Http\Request $request Request instance.
      * @param Http\Response $response Response instance.
+     * @param mixed $err
      * @return Http\Response
      */
-    public function __invoke($err, Http\Request $request, Http\Response $response)
+    public function __invoke(Http\Request $request, Http\Response $response, $err = null)
     {
         if ($err) {
             return $this->handleError($err, $request, $response);

--- a/src/Next.php
+++ b/src/Next.php
@@ -76,7 +76,7 @@ class Next
 
         // No middleware remains; done
         if ($this->queue->isEmpty()) {
-            return $done($err, $request, $response);
+            return $done($request, $response, $err);
         }
 
         $layer           = $this->queue->dequeue();

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -25,35 +25,35 @@ class FinalHandlerTest extends TestCase
     public function testInvokingWithErrorAndNoStatusCodeSetsStatusTo500()
     {
         $error    = 'error';
-        $response = call_user_func($this->final, $error, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
         $this->assertEquals(500, $response->getStatusCode());
     }
 
     public function testInvokingWithExceptionWithValidCodeSetsStatusToExceptionCode()
     {
         $error    = new Exception('foo', 400);
-        $response = call_user_func($this->final, $error, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
         $this->assertEquals(400, $response->getStatusCode());
     }
 
     public function testInvokingWithExceptionWithInvalidCodeSetsStatusTo500()
     {
         $error    = new Exception('foo', 32001);
-        $response = call_user_func($this->final, $error, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
         $this->assertEquals(500, $response->getStatusCode());
     }
 
     public function testInvokingWithErrorInNonProductionModeSetsResponseBodyToError()
     {
         $error    = 'error';
-        $response = call_user_func($this->final, $error, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
         $this->assertEquals($error, (string) $response->getBody());
     }
 
     public function testInvokingWithExceptionInNonProductionModeIncludesExceptionMessageInResponseBody()
     {
         $error    = new Exception('foo', 400);
-        $response = call_user_func($this->final, $error, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
         $expected = $this->escaper->escapeHtml($error->getMessage());
         $this->assertContains($expected, (string) $response->getBody());
     }
@@ -61,7 +61,7 @@ class FinalHandlerTest extends TestCase
     public function testInvokingWithExceptionInNonProductionModeIncludesTraceInResponseBody()
     {
         $error    = new Exception('foo', 400);
-        $response = call_user_func($this->final, $error, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
         $expected = $this->escaper->escapeHtml($error->getTraceAsString());
         $this->assertContains($expected, (string) $response->getBody());
     }
@@ -72,7 +72,7 @@ class FinalHandlerTest extends TestCase
             'env' => 'production',
         ]);
         $error    = new Exception('foo', 400);
-        $response = $final($error, $this->request, $this->response);
+        $response = $final($this->request, $this->response, $error);
         $this->assertEquals($response->getReasonPhrase(), (string) $response->getBody());
     }
 
@@ -88,7 +88,7 @@ class FinalHandlerTest extends TestCase
             'env' => 'production',
             'onerror' => $callback,
         ]);
-        $response = $final($error, $this->request, $this->response);
+        $response = $final($this->request, $this->response, $error);
         $this->assertInternalType('array', $triggered);
         $this->assertEquals(3, count($triggered));
         $this->assertSame($error, array_shift($triggered));
@@ -98,7 +98,7 @@ class FinalHandlerTest extends TestCase
 
     public function testCreates404ResponseWhenNoErrorIsPresent()
     {
-        $response = call_user_func($this->final, null, $this->request, $this->response);
+        $response = call_user_func($this->final, $this->request, $this->response, null);
         $this->assertEquals(404, $response->getStatusCode());
     }
 
@@ -110,7 +110,7 @@ class FinalHandlerTest extends TestCase
         $request     = $request->withUri(new Uri('http://local.example.com/foo'));
 
         $final    = new FinalHandler();
-        $response = call_user_func($final, null, $request, $this->response);
+        $response = call_user_func($final, $request, $this->response, null);
         $this->assertContains($originalUrl, (string) $response->getBody());
     }
 }

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -25,12 +25,30 @@ class NextTest extends TestCase
     {
         // e.g., 0 length array, or all handlers call next
         $triggered = null;
-        $done = function ($err = null) use (&$triggered) {
+        $done = function ($req, $res, $err = null) use (&$triggered) {
             $triggered = true;
         };
 
         $next = new Next($this->queue, $done);
         $next($this->request, $this->response);
+        $this->assertTrue($triggered);
+    }
+
+    public function testDoneHandlerReceivesRequestAndResponse()
+    {
+        // e.g., 0 length array, or all handlers call next
+        $phpunit   = $this;
+        $request   = $this->request;
+        $response  = $this->response;
+        $triggered = null;
+        $done = function ($req, $res, $err = null) use ($phpunit, $request, $response, &$triggered) {
+            $phpunit->assertSame($request, $req);
+            $phpunit->assertSame($response, $response);
+            $triggered = true;
+        };
+
+        $next = new Next($this->queue, $done);
+        $next($request, $response);
         $this->assertTrue($triggered);
     }
 
@@ -44,7 +62,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route);
 
         $triggered = null;
-        $done = function ($err = null) use (&$triggered) {
+        $done = function ($req, $res, $err = null) use (&$triggered) {
             $triggered = true;
         };
 
@@ -65,7 +83,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route);
 
         $triggered = null;
-        $done = function ($err = null) use (&$triggered) {
+        $done = function ($req, $res, $err = null) use (&$triggered) {
             $triggered = true;
         };
 
@@ -86,7 +104,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route);
 
         $phpunit = $this;
-        $done = function ($err = null) use ($phpunit) {
+        $done = function ($req, $res, $err = null) use ($phpunit) {
             $phpunit->fail('Should not hit done handler');
         };
 
@@ -108,7 +126,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route);
 
         $phpunit = $this;
-        $done = function ($err = null) use ($phpunit) {
+        $done = function ($req, $res, $err = null) use ($phpunit) {
             $phpunit->fail('Should not hit done handler');
         };
 
@@ -137,7 +155,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route3);
 
         $phpunit = $this;
-        $done = function ($err) use ($phpunit) {
+        $done = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
@@ -166,7 +184,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route2);
         $this->queue->enqueue($route3);
 
-        $done = function ($err) use ($phpunit) {
+        $done = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
@@ -193,7 +211,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route1);
         $this->queue->enqueue($route2);
 
-        $done = function ($err) use ($phpunit) {
+        $done = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
@@ -222,7 +240,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route1);
         $this->queue->enqueue($route2);
 
-        $done = function ($err) use ($phpunit) {
+        $done = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
@@ -246,7 +264,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route1);
         $this->queue->enqueue($route2);
 
-        $done = function ($err) use ($phpunit) {
+        $done = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 
@@ -271,7 +289,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route1);
         $this->queue->enqueue($route2);
 
-        $done = function ($err) use ($phpunit) {
+        $done = function ($req, $res, $err) use ($phpunit) {
             $phpunit->fail('Should not hit final handler');
         };
 


### PR DESCRIPTION
Now that the signature of `Next` has changed, the `$done` callable composed by `Next` must follow the same signature. This means:

- Changing how `$done` is invoked.
- Fixing `FinalHandler::__invoke()` to follow the same signature.

The primary motivation for this was discovering that nested middleware was not working. Nested middleware receives the parent's `$next` instance as its `$done` callable, and when invoking it, was invoking with the arguments in the incorrect order.

This patch adds a unit test for the above case, and updates the code accordingly.