### PR TITLE
Update to psr/http-message 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.13.0 - 2015-01-28
+
+This release updates its dependencies to use psr/http-message >= 0.8.0 and
+phly/http >= 0.10.0. The primary changes that affect Conduit regard changes to
+`Psr\Http\Message\RequestInterface` and the renaming of
+`Psr\Http\Message\UriTargetInterface` to `Psr\Http\Message\UriInterface`, which
+required changes in `Phly\Conduit\Http\Request`.
+
+### Added
+
+- `Phly\Conduit\Http\Request::getRequestTarget()`, to fetch the request-target.
+- `Phly\Conduit\Http\Request::withRequestTarget()`, to allow creating a new
+  instance with the specified request-target, allowing developers to set a
+  non-origin-form request-target.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- `Phly\Conduit\Http\Request` now typehints against
+  `Psr\Http\Message\UriInterface` for methods dealing with the URI.
+
 ## 0.12.0 - 2015-01-27
 
 This release makes one backwards-incompatible change: Due to the changes in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation and Requirements
 Install this library using composer:
 
 ```console
-$ composer require "psr/http-message:~0.6.0@dev" "phly/http:~1.0-dev@dev" "phly/conduit:~1.0-dev@dev"
+$ composer require "psr/http-message:~0.8.0@dev" "phly/http:~1.0-dev@dev" "phly/conduit:~1.0-dev@dev"
 ```
 
 Conduit has the following dependencies (which are managed by Composer):

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": "~0.9.0",
-    "psr/http-message": "~0.6.0",
+    "phly/http": "~0.10.0",
+    "psr/http-message": "~0.8.0",
     "zendframework/zend-escaper": "~2.3@stable"
   },
   "require-dev": {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,10 +1,9 @@
 <?php
 namespace Phly\Conduit\Http;
 
-use ArrayObject;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamableInterface;
-use Psr\Http\Message\UriTargetInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Decorator for PSR ServerRequestInterface
@@ -66,6 +65,16 @@ class Request implements ServerRequestInterface
     }
 
     /**
+     * Proxy to ServerRequestInterface::getRequestTarget()
+     * 
+     * @return string Request's request-target
+     */
+    public function getRequestTarget()
+    {
+        return $this->psrRequest->getRequestTarget();
+    }
+
+    /**
      * Proxy to ServerRequestInterface::getProtocolVersion()
      *
      * @return string HTTP protocol version.
@@ -73,6 +82,19 @@ class Request implements ServerRequestInterface
     public function getProtocolVersion()
     {
         return $this->psrRequest->getProtocolVersion();
+    }
+
+    /**
+     * Proxy to ServerRequestInterface::withRequestTarget()
+     * 
+     * @param string $requestTarget 
+     * @return self
+     * @throws \InvalidArgumentException
+     */
+    public function withRequestTarget($requestTarget)
+    {
+        $new = $this->psrRequest->withRequestTarget($requestTarget);
+        return new self($new, $this->originalRequest);
     }
 
     /**
@@ -218,7 +240,7 @@ class Request implements ServerRequestInterface
     /**
      * Proxy to ServerRequestInterface::getUri()
      *
-     * @return UriTargetInterface Returns a UriTargetInterface instance
+     * @return UriInterface Returns a UriInterface instance
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      */
     public function getUri()
@@ -230,11 +252,11 @@ class Request implements ServerRequestInterface
      * Allow mutating the URI
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param UriTargetInterface $uri Request URI.
+     * @param UriInterface $uri Request URI.
      * @return self
      * @throws \InvalidArgumentException If the URI is invalid.
      */
-    public function withUri(UriTargetInterface $uri)
+    public function withUri(UriInterface $uri)
     {
         $new = $this->psrRequest->withUri($uri);
         return new self($new, $this->originalRequest);

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -65,5 +65,6 @@ class RequestTest extends TestCase
         $this->assertEquals('1.1', $request->getProtocolVersion());
         $this->assertSame($stream, $request->getBody());
         $this->assertSame($psrRequest->getHeaders(), $request->getHeaders());
+        $this->assertEquals($psrRequest->getRequestTarget(), $request->getRequestTarget());
     }
 }


### PR DESCRIPTION
Updated Request to follow changes to RequestInterface

Adds the methods `getRequestTarget()` and `withRequestTarget()`;
additionally, it changes the methods dealing with the URI to reference
`UriInterface`.