### PR TITLE
Update to psr/http-message 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release..
 
+## 0.14.0 - TBD
+
+This release updates its dependencies to use psr/http-message >= 0.9.0 and
+phly/http >= 0.11.0. The primary changes that affect Conduit regard changes to
+`Psr\Http\Message\ServerRequestInterface`, which required method name and
+signature changes in `Phly\Conduit\Http\Request`.
+
+### Added
+
+- `Phly\Conduit\Http\Request::getParsedBody()` (replaces `getBodyParams()`).
+- `Phly\Conduit\Http\Request::withParsedBody()` (replaces `withBodyParams()`).
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- `Phly\Conduit\Http\Request::getBodyParams()` (replaced by `getParsedBody()`).
+- `Phly\Conduit\Http\Request::withBodyParams()` (replaced by `withParsedBody()`).
+
+### Fixed
+
+- Nothing.
+
 ## 0.13.0 - 2015-01-28
 
 This release updates its dependencies to use psr/http-message >= 0.8.0 and

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   },
   "require": {
     "php": ">=5.4.8",
-    "phly/http": "~0.10.0",
-    "psr/http-message": "~0.8.0",
+    "phly/http": "dev-feature/parsed-body@dev",
+    "psr/http-message": "dev-feature/parsed-body@dev",
     "zendframework/zend-escaper": "~2.3@stable"
   },
   "require-dev": {
@@ -44,5 +44,15 @@
     "psr-4": {
       "PhlyTest\\Conduit\\": "test/"
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/weierophinney/http-message.git"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/weierophinney/http.git"
+    }
+  ]
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -327,25 +327,25 @@ class Request implements ServerRequestInterface
     }
 
     /**
-     * Proxy to ServerRequestInterface::getBodyParams()
+     * Proxy to ServerRequestInterface::getParsedBody()
      *
      *
      * @return array The deserialized body parameters, if any.
      */
-    public function getBodyParams()
+    public function getParsedBody()
     {
-        return $this->psrRequest->getBodyParams();
+        return $this->psrRequest->getParsedBody();
     }
 
     /**
-     * Proxy to ServerRequestInterface::withBodyParams()
+     * Proxy to ServerRequestInterface::withParsedBody()
      *
-     * @param array $params The deserialized body parameters.
+     * @param null|array|object $params The deserialized body parameters.
      * @return self
      */
-    public function withBodyParams(array $params)
+    public function withParsedBody($params)
     {
-        $new = $this->psrRequest->withBodyParams($params);
+        $new = $this->psrRequest->withParsedBody($params);
         return new self($new, $this->originalRequest);
     }
 


### PR DESCRIPTION
Updates to sync Conduit with changes in psr/http-message, which involve renaming "BodyParams" to "ParsedBody", and changing the signature of `withParsedBody()` to remove the `array` typehint.