### PR TITLE
php 5.4 type hinting

### DIFF
--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -92,16 +92,11 @@ class MiddlewarePipe implements MiddlewareInterface
      * @param null|callable|object $middleware Middleware
      * @return self
      */
-    public function pipe($path, $middleware = null)
+    public function pipe($path, callable $middleware = null)
     {
         if (null === $middleware && is_callable($path)) {
             $middleware = $path;
             $path       = '/';
-        }
-
-        // Ensure we have a valid handler
-        if (! is_callable($middleware)) {
-            throw new InvalidArgumentException('Middleware must be callable');
         }
 
         $this->pipeline->enqueue(new Route(


### PR DESCRIPTION
shouldn't this do the same? unless you need to show a custom exception message.

- the first condition ensure that if $path is used as the middleware then it is callable.
- callable type hinting allows null values but only callable not null values
